### PR TITLE
Harden admin authentication per hotel

### DIFF
--- a/core/admin.php
+++ b/core/admin.php
@@ -11,7 +11,13 @@ require_once __DIR__ . '/init.php';
 // Relativer Pfad zum Core‑Verzeichnis (vom Hotel‑Wrapper gesetzt)
 $coreRelative = $coreRelative ?? '.';
 
-if (!isset($_SESSION['admin']) || $_SESSION['admin'] !== true) {
+$adminSessionKey = $ADMIN_SESSION_KEY ?? 'admin';
+$sessionData = $_SESSION[$adminSessionKey] ?? null;
+$isAuthenticated = is_array($sessionData)
+    ? (!empty($sessionData['authenticated']))
+    : ($sessionData === true);
+
+if (!$isAuthenticated) {
     header('Location: login.php');
     exit;
 }

--- a/core/analysis.php
+++ b/core/analysis.php
@@ -11,7 +11,13 @@ require_once __DIR__ . '/init.php';
 // Relativer Pfad zum Core-Verzeichnis (vom Hotel-Wrapper gesetzt)
 $coreRelative = $coreRelative ?? '.';
 
-if (!isset($_SESSION['admin']) || $_SESSION['admin'] !== true) {
+$adminSessionKey = $ADMIN_SESSION_KEY ?? 'admin';
+$sessionData = $_SESSION[$adminSessionKey] ?? null;
+$isAuthenticated = is_array($sessionData)
+    ? (!empty($sessionData['authenticated']))
+    : ($sessionData === true);
+
+if (!$isAuthenticated) {
     header('Location: login.php');
     exit;
 }

--- a/core/config.sample.php
+++ b/core/config.sample.php
@@ -27,3 +27,7 @@ $ADMIN_USER = 'admin';
 $ADMIN_PASSWORD_HASH = password_hash('changeme', PASSWORD_DEFAULT);
 
 // Hinweis: Diese Datei ist nur ein Beispiel. Für jedes Hotel sollten Sie eine eigene config.php mit angepassten Werten anlegen.
+
+// Optional: Eindeutiger Schlüssel für das Hotel (z. B. für Session-Namespace).
+// Wird er nicht gesetzt, nutzt das System automatisch den Namen des Hotelordners.
+// $HOTEL_KEY = 'mein-hotel';

--- a/core/faq_editor.php
+++ b/core/faq_editor.php
@@ -13,7 +13,13 @@ require_once __DIR__ . '/init.php';
 // Relativer Pfad zum Core‑Verzeichnis (vom Hotel‑Wrapper gesetzt)
 $coreRelative = $coreRelative ?? '.';
 
-if (!isset($_SESSION['admin']) || $_SESSION['admin'] !== true) {
+$adminSessionKey = $ADMIN_SESSION_KEY ?? 'admin';
+$sessionData = $_SESSION[$adminSessionKey] ?? null;
+$isAuthenticated = is_array($sessionData)
+    ? (!empty($sessionData['authenticated']))
+    : ($sessionData === true);
+
+if (!$isAuthenticated) {
     header('Location: login.php');
     exit;
 }

--- a/core/init.php
+++ b/core/init.php
@@ -18,13 +18,29 @@ if (session_status() === PHP_SESSION_NONE) {
 
 // Ermitteln und Laden der Konfiguration
 if (isset($configPath) && file_exists($configPath)) {
+    $resolvedConfig = realpath($configPath);
     require $configPath;
 } elseif (file_exists(__DIR__ . '/../config.php')) {
     // Fallback für Entwicklungszwecke: lokale config.php im Projekt
+    $resolvedConfig = realpath(__DIR__ . '/../config.php');
     require __DIR__ . '/../config.php';
 } else {
     // Keine Konfiguration gefunden => Fehlermeldung ausgeben
     die('Konfigurationsdatei nicht gefunden. Bitte setzen Sie $configPath vor dem Einbinden von init.php.');
+}
+
+// Eindeutigen Schlüssel für das Hotel ableiten (Konfiguration kann optional $HOTEL_KEY setzen)
+if (!isset($HOTEL_KEY) || !is_string($HOTEL_KEY) || $HOTEL_KEY === '') {
+    if (isset($resolvedConfig) && $resolvedConfig !== false) {
+        $HOTEL_KEY = basename(dirname($resolvedConfig));
+    } else {
+        $HOTEL_KEY = 'default';
+    }
+}
+
+// Session-Namespace für die Admin-Authentifizierung vorbereiten
+if (!isset($ADMIN_SESSION_KEY) || !is_string($ADMIN_SESSION_KEY) || $ADMIN_SESSION_KEY === '') {
+    $ADMIN_SESSION_KEY = 'admin_auth_' . hash('sha256', $HOTEL_KEY);
 }
 
 // Einrichtung der SQLite‑Datenbank für die Protokollierung

--- a/core/logout.php
+++ b/core/logout.php
@@ -1,10 +1,23 @@
 <?php
 /**
- * Beendet die Administrator‑Session und leitet zum Login zurück.
+ * Beendet ausschließlich die Administrator-Session des aktuellen Hotels
+ * und leitet anschließend zur Login-Seite zurück.
  */
 
+$configPath = $configPath ?? null;
+
 session_start();
-session_unset();
-session_destroy();
+require_once __DIR__ . '/init.php';
+
+$adminSessionKey = $ADMIN_SESSION_KEY ?? 'admin';
+
+if (isset($_SESSION[$adminSessionKey])) {
+    unset($_SESSION[$adminSessionKey]);
+}
+
+// Session-Fixation vorbeugen
+session_regenerate_id(true);
+
 header('Location: login.php');
 exit;
+


### PR DESCRIPTION
## Summary
- derive a per-hotel admin session namespace during init to keep logins scoped to the current tenant
- harden the login flow with constant-time username comparison, session regeneration, and scoped session payloads while improving form autofill hints
- gate admin-only pages and logout against the new session key and document the optional HOTEL_KEY override in the sample config

## Testing
- php -l core/init.php
- php -l core/login.php
- php -l core/admin.php
- php -l core/faq_editor.php
- php -l core/analysis.php
- php -l core/logout.php

------
https://chatgpt.com/codex/tasks/task_e_68ce9996100083249e6be8ea9a1c15d7