### PR TITLE
Refactor admin area into tabbed dashboard

### DIFF
--- a/core/admin.php
+++ b/core/admin.php
@@ -1,54 +1,440 @@
 <?php
 /**
- * Übersichtsseite für den Administrationsbereich.
- *
- * Hier werden Links zum FAQ‑Editor, zur Analyse und zum Logout angeboten.
+ * Administrationsoberfläche mit Reitern für Analyse, FAQ und Einstellungen.
  */
 
 session_start();
 require_once __DIR__ . '/init.php';
+require_once __DIR__ . '/analytics_helpers.php';
+require_once __DIR__ . '/admin_accounts.php';
 
-// Relativer Pfad zum Core‑Verzeichnis (vom Hotel‑Wrapper gesetzt)
+/**
+ * Filtert Flash-Meldungen für einen Tab.
+ *
+ * @param array<int,array<string,mixed>> $messages
+ * @param string $tab
+ * @return array<int,array<string,mixed>>
+ */
+function admin_filter_flash(array $messages, string $tab): array
+{
+    $filtered = [];
+    foreach ($messages as $message) {
+        if (!is_array($message)) {
+            continue;
+        }
+        if (($message['tab'] ?? '') === $tab) {
+            $filtered[] = $message;
+        }
+    }
+    return $filtered;
+}
+
+/**
+ * Aktualisiert definierte Werte in der Konfigurationsdatei.
+ *
+ * @param string|null $configPath
+ * @param array<string,string> $values
+ * @param array<int,string> $errors
+ */
+function admin_update_config_values(?string $configPath, array $values, array &$errors): bool
+{
+    if (!$configPath || !is_string($configPath)) {
+        $errors[] = 'Konfigurationspfad konnte nicht ermittelt werden.';
+        return false;
+    }
+
+    if (!is_file($configPath)) {
+        $errors[] = 'Konfigurationsdatei wurde nicht gefunden.';
+        return false;
+    }
+
+    $contents = file_get_contents($configPath);
+    if ($contents === false) {
+        $errors[] = 'Konfigurationsdatei konnte nicht gelesen werden.';
+        return false;
+    }
+
+    foreach ($values as $key => $value) {
+        $exported = var_export($value, true);
+        $pattern = '/\$' . preg_quote($key, '/') . '\s*=\s*[^;]*;/m';
+        if (preg_match($pattern, $contents)) {
+            $contents = preg_replace($pattern, '$' . $key . ' = ' . $exported . ';', $contents, 1);
+        } else {
+            $contents = rtrim($contents) . PHP_EOL . '$' . $key . ' = ' . $exported . ';' . PHP_EOL;
+        }
+    }
+
+    if (@file_put_contents($configPath, $contents) === false) {
+        $errors[] = 'Konfigurationsdatei konnte nicht gespeichert werden.';
+        return false;
+    }
+
+    return true;
+}
+
+// Relativer Pfad zum Core-Verzeichnis (vom Hotel-Wrapper gesetzt)
 $coreRelative = $coreRelative ?? '.';
 
-if (!isset($_SESSION['admin']) || $_SESSION['admin'] !== true) {
+$adminSessionKey = $ADMIN_SESSION_KEY ?? 'admin';
+$sessionData = $_SESSION[$adminSessionKey] ?? null;
+$isAuthenticated = is_array($sessionData)
+    ? (!empty($sessionData['authenticated']))
+    : ($sessionData === true);
+
+if (!$isAuthenticated) {
     header('Location: login.php');
     exit;
 }
+
+$validTabs = ['analysis', 'faq', 'settings'];
+$activeTab = isset($_GET['tab']) ? strtolower((string)$_GET['tab']) : 'analysis';
+if (!in_array($activeTab, $validTabs, true)) {
+    $activeTab = 'analysis';
+}
+
+$flashMessages = $_SESSION['admin_flash'] ?? [];
+unset($_SESSION['admin_flash']);
+
+$accountsFile = admin_accounts_file_path($HOTEL_BASE_PATH ?? null);
+$availableAccounts = admin_load_accounts(
+    $accountsFile,
+    $ADMIN_USERS ?? null,
+    $ADMIN_USER ?? null,
+    $ADMIN_PASSWORD_HASH ?? null
+);
+
+$faqPath = isset($FAQ_FILE) ? $FAQ_FILE : null;
+$faqContent = '';
+if ($faqPath && is_readable($faqPath)) {
+    $faqContent = (string)file_get_contents($faqPath);
+}
+$faqError = '';
+
+$settingsValues = [
+    'HOTEL_NAME' => isset($HOTEL_NAME) ? (string)$HOTEL_NAME : '',
+    'HOTEL_URL'  => isset($HOTEL_URL) ? (string)$HOTEL_URL : '',
+    'API_URL'    => isset($API_URL) ? (string)$API_URL : '',
+    'BOT_NAME'   => isset($BOT_NAME) ? (string)$BOT_NAME : '',
+];
+$settingsErrors = [];
+
+$accountsFormData = [];
+foreach ($availableAccounts as $account) {
+    $accountsFormData[] = [
+        'username' => $account['username'],
+        'existing_hash' => $account['password_hash'],
+    ];
+}
+if (empty($accountsFormData)) {
+    $accountsFormData[] = ['username' => '', 'existing_hash' => ''];
+}
+
+$analysisFiltersNormalized = analytics_normalize_filters($_GET);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'save_faq') {
+        $activeTab = 'faq';
+        $newContent = (string)($_POST['content'] ?? '');
+
+        if (!$faqPath) {
+            $faqError = 'FAQ-Datei ist in der Konfiguration nicht definiert.';
+        } else {
+            $dir = dirname($faqPath);
+            if (!is_dir($dir)) {
+                @mkdir($dir, 0775, true);
+            }
+            if (@file_put_contents($faqPath, $newContent) === false) {
+                $faqError = 'FAQ konnte nicht gespeichert werden. Prüfen Sie die Schreibrechte.';
+            } else {
+                $_SESSION['admin_flash'][] = [
+                    'tab' => 'faq',
+                    'type' => 'success',
+                    'text' => 'FAQ wurde erfolgreich gespeichert.',
+                ];
+                header('Location: admin.php?tab=faq');
+                exit;
+            }
+        }
+
+        $faqContent = $newContent;
+    }
+
+    if ($action === 'save_settings') {
+        $activeTab = 'settings';
+        $postedSettings = isset($_POST['settings']) && is_array($_POST['settings']) ? $_POST['settings'] : [];
+        $newSettings = [];
+        foreach ($settingsValues as $key => $current) {
+            $value = isset($postedSettings[$key]) ? trim((string)$postedSettings[$key]) : '';
+            $settingsValues[$key] = $value;
+            $newSettings[$key] = $value;
+        }
+
+        $accountsPost = isset($_POST['accounts']) && is_array($_POST['accounts']) ? $_POST['accounts'] : [];
+        $accountsFormData = [];
+        $normalizedAccounts = [];
+        $seenUsernames = [];
+
+        foreach ($accountsPost as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+            $username = isset($row['username']) ? trim((string)$row['username']) : '';
+            $password = isset($row['password']) ? (string)$row['password'] : '';
+            $existingHash = isset($row['existing_hash']) ? (string)$row['existing_hash'] : '';
+            $remove = !empty($row['remove']);
+
+            $accountsFormData[] = [
+                'username' => $username,
+                'existing_hash' => $existingHash,
+            ];
+
+            if ($remove) {
+                continue;
+            }
+
+            if ($username === '') {
+                $settingsErrors[] = 'Benutzername darf nicht leer sein.';
+                continue;
+            }
+
+            $usernameKey = strtolower($username);
+            if (isset($seenUsernames[$usernameKey])) {
+                $settingsErrors[] = 'Benutzername "' . $username . '" ist mehrfach vorhanden.';
+                continue;
+            }
+            $seenUsernames[$usernameKey] = true;
+
+            if ($password !== '') {
+                $hash = password_hash($password, PASSWORD_DEFAULT);
+            } else {
+                $hash = $existingHash;
+            }
+
+            if ($hash === '') {
+                $settingsErrors[] = 'Für Benutzer "' . $username . '" muss ein Passwort vergeben werden.';
+                continue;
+            }
+
+            $normalizedAccounts[] = [
+                'username' => $username,
+                'password_hash' => $hash,
+            ];
+        }
+
+        if (empty($normalizedAccounts)) {
+            $settingsErrors[] = 'Mindestens ein Admin-Benutzer ist erforderlich.';
+        }
+
+        $configErrors = [];
+        if (empty($settingsErrors)) {
+            if (!admin_update_config_values($HOTEL_CONFIG_PATH ?? null, $newSettings, $configErrors)) {
+                $settingsErrors = array_merge($settingsErrors, $configErrors);
+            } else {
+                foreach ($newSettings as $key => $value) {
+                    $$key = $value;
+                }
+            }
+        }
+
+        if (empty($settingsErrors)) {
+            $saveError = null;
+            if (!admin_save_accounts($accountsFile, $normalizedAccounts, $saveError)) {
+                $settingsErrors[] = $saveError ?: 'Admin-Benutzer konnten nicht gespeichert werden.';
+            } else {
+                $_SESSION['admin_flash'][] = [
+                    'tab' => 'settings',
+                    'type' => 'success',
+                    'text' => 'Einstellungen wurden gespeichert.',
+                ];
+                header('Location: admin.php?tab=settings');
+                exit;
+            }
+        }
+
+        if (!empty($settingsErrors) && empty($accountsFormData)) {
+            $accountsFormData[] = ['username' => '', 'existing_hash' => ''];
+        }
+    }
+}
+
+$analysisFiltersQuery = analytics_query_string($analysisFiltersNormalized);
+if ($activeTab === 'analysis' && isset($_GET['export']) && $_GET['export'] === 'csv') {
+    analytics_export_csv($db ?? null, $analysisFiltersNormalized);
+}
+$analysisData = analytics_fetch_data($db ?? null, $analysisFiltersNormalized);
+$analysisFiltersForView = $analysisFiltersNormalized;
+$analysisFiltersForView['tab'] = 'analysis';
+$analysisExportUrl = 'admin.php?' . ($analysisFiltersQuery ? $analysisFiltersQuery . '&' : '') . 'tab=analysis&export=csv';
+$analysisTabUrl = 'admin.php?tab=analysis' . ($analysisFiltersQuery ? '&' . $analysisFiltersQuery : '');
+
+$faqFlash = admin_filter_flash($flashMessages, 'faq');
+$settingsFlash = admin_filter_flash($flashMessages, 'settings');
 ?>
 <!DOCTYPE html>
 <html lang="de">
 <head>
     <meta charset="UTF-8">
     <title>Admin Bereich</title>
-    <!-- Gemeinsames Stylesheet aus dem Core einbinden -->
     <link rel="stylesheet" href="<?php echo htmlspecialchars($coreRelative); ?>/assets/css/style.css">
-    <style>
-    body {
-        padding: 20px;
-        font-family: Arial, Helvetica, sans-serif;
-    }
-    ul { list-style: none; padding: 0; }
-    li { margin-bottom: 10px; }
-    a.button {
-        display: inline-block;
-        padding: 8px 12px;
-        background: #003366;
-        color: #fff;
-        border-radius: 4px;
-        text-decoration: none;
-    }
-    a.button:hover {
-        background: #004080;
-    }
-    </style>
 </head>
-<body>
-    <h1>Admin Bereich – <?php echo htmlspecialchars($HOTEL_NAME); ?></h1>
-    <ul>
-        <li><a class="button" href="faq_editor.php">FAQ bearbeiten</a></li>
-        <li><a class="button" href="analysis.php">Anfragen analysieren</a></li>
-        <li><a class="button" href="logout.php">Logout</a></li>
-    </ul>
+<body class="admin-dashboard">
+  <div class="admin-shell">
+    <header class="admin-header">
+      <div>
+        <h1>Admin – <?php echo htmlspecialchars($HOTEL_NAME ?? ''); ?></h1>
+        <p class="muted">Verwalten Sie Inhalte, Auswertungen und Zugänge für <?php echo htmlspecialchars($HOTEL_NAME ?? 'Ihr Hotel'); ?>.</p>
+      </div>
+      <div class="header-actions">
+        <a class="button ghost" href="logout.php">Logout</a>
+      </div>
+    </header>
+
+    <nav class="tab-nav">
+      <a class="tab-link <?php echo $activeTab === 'analysis' ? 'active' : ''; ?>" href="<?php echo htmlspecialchars($analysisTabUrl); ?>">Analyse</a>
+      <a class="tab-link <?php echo $activeTab === 'faq' ? 'active' : ''; ?>" href="?tab=faq">FAQ</a>
+      <a class="tab-link <?php echo $activeTab === 'settings' ? 'active' : ''; ?>" href="?tab=settings">Einstellungen</a>
+    </nav>
+
+    <div class="tab-panels">
+      <section class="tab-panel <?php echo $activeTab === 'analysis' ? 'active' : ''; ?>" id="panel-analysis">
+        <?php
+          $analysisFilters = $analysisFiltersForView;
+          $exportUrl = $analysisExportUrl;
+          $backLink = null;
+          include __DIR__ . '/partials/analysis_content.php';
+        ?>
+      </section>
+
+      <section class="tab-panel <?php echo $activeTab === 'faq' ? 'active' : ''; ?>" id="panel-faq">
+        <div class="card">
+          <h2>FAQ bearbeiten</h2>
+          <?php foreach ($faqFlash as $message): ?>
+            <div class="flash <?php echo htmlspecialchars($message['type'] ?? 'info'); ?>"><?php echo htmlspecialchars($message['text'] ?? ''); ?></div>
+          <?php endforeach; ?>
+          <?php if ($faqError): ?>
+            <div class="flash error"><?php echo htmlspecialchars($faqError); ?></div>
+          <?php endif; ?>
+          <form method="post" class="stacked-form">
+            <input type="hidden" name="action" value="save_faq">
+            <textarea name="content" rows="20" spellcheck="false"><?php echo htmlspecialchars($faqContent); ?></textarea>
+            <div class="form-actions">
+              <button type="submit" class="primary">FAQ speichern</button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section class="tab-panel <?php echo $activeTab === 'settings' ? 'active' : ''; ?>" id="panel-settings">
+        <form method="post" class="stacked-form settings-form">
+          <input type="hidden" name="action" value="save_settings">
+          <div class="card">
+            <h2>Allgemeine Einstellungen</h2>
+            <?php foreach ($settingsFlash as $message): ?>
+              <div class="flash <?php echo htmlspecialchars($message['type'] ?? 'info'); ?>"><?php echo htmlspecialchars($message['text'] ?? ''); ?></div>
+            <?php endforeach; ?>
+            <?php if (!empty($settingsErrors)): ?>
+              <div class="flash error">
+                <ul>
+                  <?php foreach ($settingsErrors as $error): ?>
+                    <li><?php echo htmlspecialchars($error); ?></li>
+                  <?php endforeach; ?>
+                </ul>
+              </div>
+            <?php endif; ?>
+            <div class="grid two-cols">
+              <label class="field">
+                <span>Hotelname</span>
+                <input type="text" name="settings[HOTEL_NAME]" value="<?php echo htmlspecialchars($settingsValues['HOTEL_NAME']); ?>" required>
+              </label>
+              <label class="field">
+                <span>Hotel-Website</span>
+                <input type="url" name="settings[HOTEL_URL]" value="<?php echo htmlspecialchars($settingsValues['HOTEL_URL']); ?>" placeholder="https://...">
+              </label>
+              <label class="field">
+                <span>API-Endpunkt</span>
+                <input type="url" name="settings[API_URL]" value="<?php echo htmlspecialchars($settingsValues['API_URL']); ?>" placeholder="https://...">
+              </label>
+              <label class="field">
+                <span>Bot-Name</span>
+                <input type="text" name="settings[BOT_NAME]" value="<?php echo htmlspecialchars($settingsValues['BOT_NAME']); ?>">
+              </label>
+            </div>
+          </div>
+
+          <div class="card">
+            <h2>Admin-Benutzer</h2>
+            <p class="muted">Vergeben Sie individuelle Zugänge. Lassen Sie das Passwortfeld leer, wenn es unverändert bleiben soll.</p>
+            <div class="account-list" data-next-index="<?php echo count($accountsFormData); ?>">
+              <?php foreach ($accountsFormData as $idx => $account): ?>
+                <div class="account-row" data-account-row>
+                  <label class="field">
+                    <span>Benutzername</span>
+                    <input type="text" name="accounts[<?php echo $idx; ?>][username]" value="<?php echo htmlspecialchars($account['username']); ?>">
+                  </label>
+                  <label class="field">
+                    <span>Neues Passwort</span>
+                    <input type="password" name="accounts[<?php echo $idx; ?>][password]" autocomplete="new-password" placeholder="Nur ausfüllen, wenn ändern">
+                  </label>
+                  <label class="field checkbox">
+                    <input type="checkbox" name="accounts[<?php echo $idx; ?>][remove]" value="1">
+                    <span>Entfernen</span>
+                  </label>
+                  <input type="hidden" name="accounts[<?php echo $idx; ?>][existing_hash]" value="<?php echo htmlspecialchars($account['existing_hash']); ?>">
+                </div>
+              <?php endforeach; ?>
+            </div>
+            <button type="button" class="button ghost add-account" data-add-account>+ Benutzer hinzufügen</button>
+          </div>
+
+          <div class="form-actions">
+            <button type="submit" class="primary">Einstellungen speichern</button>
+          </div>
+        </form>
+      </section>
+    </div>
+  </div>
+
+  <template id="account-template">
+    <div class="account-row" data-account-row>
+      <label class="field">
+        <span>Benutzername</span>
+        <input type="text" name="accounts[__INDEX__][username]" value="">
+      </label>
+      <label class="field">
+        <span>Passwort</span>
+        <input type="password" name="accounts[__INDEX__][password]" autocomplete="new-password" placeholder="Neues Passwort">
+      </label>
+      <label class="field checkbox">
+        <input type="checkbox" name="accounts[__INDEX__][remove]" value="1">
+        <span>Entfernen</span>
+      </label>
+      <input type="hidden" name="accounts[__INDEX__][existing_hash]" value="">
+    </div>
+  </template>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const addButton = document.querySelector('[data-add-account]');
+      const list = document.querySelector('.account-list');
+      const template = document.getElementById('account-template');
+      if (!addButton || !list || !template) {
+        return;
+      }
+
+      addButton.addEventListener('click', function () {
+        const nextIndex = parseInt(list.getAttribute('data-next-index') || '0', 10);
+        const tplContent = template.innerHTML.replace(/__INDEX__/g, String(nextIndex));
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = tplContent.trim();
+        const node = wrapper.firstElementChild;
+        if (node) {
+          list.appendChild(node);
+        }
+        list.setAttribute('data-next-index', String(nextIndex + 1));
+      });
+    });
+  </script>
 </body>
 </html>

--- a/core/admin_accounts.php
+++ b/core/admin_accounts.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Hilfsfunktionen zum Laden und Speichern der Admin-Benutzer pro Hotel.
+ */
+
+/**
+ * Liefert den Pfad zur Admin-Benutzerdatei (JSON) relativ zur Hotelbasis.
+ */
+function admin_accounts_file_path(?string $hotelBasePath): string
+{
+    $base = $hotelBasePath ?: __DIR__;
+    return rtrim($base, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR . 'admin_users.json';
+}
+
+/**
+ * Normalisiert ein Benutzer-Array und gibt nur gültige Einträge zurück.
+ *
+ * @param array<int,array<string,mixed>> $accounts
+ * @return array<int,array{username:string,password_hash:string}>
+ */
+function admin_normalize_accounts(array $accounts): array
+{
+    $normalized = [];
+    foreach ($accounts as $account) {
+        if (!is_array($account)) {
+            continue;
+        }
+        $username = isset($account['username']) ? trim((string)$account['username']) : '';
+        $hash = isset($account['password_hash']) ? (string)$account['password_hash'] : '';
+        if ($username === '' || $hash === '') {
+            continue;
+        }
+        $normalized[] = [
+            'username' => $username,
+            'password_hash' => $hash,
+        ];
+    }
+    return $normalized;
+}
+
+/**
+ * Lädt alle verfügbaren Admin-Benutzer aus JSON-Datei oder Konfiguration.
+ *
+ * Reihenfolge der Quellen:
+ *  1. JSON-Datei (falls vorhanden)
+ *  2. $ADMIN_USERS Array aus der Konfiguration
+ *  3. Einzelner Benutzer aus $ADMIN_USER / $ADMIN_PASSWORD_HASH
+ *
+ * @param string|null $accountsFile
+ * @param mixed $configUsers
+ * @param mixed $configUser
+ * @param mixed $configHash
+ * @return array<int,array{username:string,password_hash:string}>
+ */
+function admin_load_accounts(?string $accountsFile, $configUsers, $configUser, $configHash): array
+{
+    // 1) JSON-Datei bevorzugen
+    if ($accountsFile && is_readable($accountsFile)) {
+        $json = file_get_contents($accountsFile);
+        if ($json !== false) {
+            $data = json_decode($json, true);
+            if (is_array($data)) {
+                $normalized = admin_normalize_accounts($data);
+                if (!empty($normalized)) {
+                    return $normalized;
+                }
+            }
+        }
+    }
+
+    // 2) $ADMIN_USERS aus der Konfiguration
+    if (is_array($configUsers)) {
+        $normalized = [];
+        foreach ($configUsers as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            $username = isset($entry['username']) ? trim((string)$entry['username']) : '';
+            $hash = isset($entry['password_hash']) ? (string)$entry['password_hash'] : '';
+            if ($username === '' || $hash === '') {
+                continue;
+            }
+            $normalized[] = [
+                'username' => $username,
+                'password_hash' => $hash,
+            ];
+        }
+        if (!empty($normalized)) {
+            return $normalized;
+        }
+    }
+
+    // 3) Fallback auf Einzelbenutzer
+    $user = is_string($configUser) ? trim($configUser) : '';
+    $hash = is_string($configHash) ? $configHash : '';
+    if ($user !== '' && $hash !== '') {
+        return [[
+            'username' => $user,
+            'password_hash' => $hash,
+        ]];
+    }
+
+    return [];
+}
+
+/**
+ * Speichert Admin-Benutzer als JSON-Datei.
+ *
+ * @param string $accountsFile
+ * @param array<int,array{username:string,password_hash:string}> $accounts
+ * @param string|null $error
+ * @return bool
+ */
+function admin_save_accounts(string $accountsFile, array $accounts, ?string &$error = null): bool
+{
+    $dir = dirname($accountsFile);
+    if (!is_dir($dir)) {
+        if (!@mkdir($dir, 0775, true) && !is_dir($dir)) {
+            $error = 'Verzeichnis für Admin-Benutzer konnte nicht erstellt werden.';
+            return false;
+        }
+    }
+
+    $json = json_encode($accounts, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    if ($json === false) {
+        $error = 'Benutzer konnten nicht serialisiert werden.';
+        return false;
+    }
+
+    if (@file_put_contents($accountsFile, $json) === false) {
+        $error = 'Admin-Benutzerdatei konnte nicht gespeichert werden.';
+        return false;
+    }
+
+    return true;
+}

--- a/core/analysis.php
+++ b/core/analysis.php
@@ -7,11 +7,18 @@
 
 session_start();
 require_once __DIR__ . '/init.php';
+require_once __DIR__ . '/analytics_helpers.php';
 
 // Relativer Pfad zum Core-Verzeichnis (vom Hotel-Wrapper gesetzt)
 $coreRelative = $coreRelative ?? '.';
 
-if (!isset($_SESSION['admin']) || $_SESSION['admin'] !== true) {
+$adminSessionKey = $ADMIN_SESSION_KEY ?? 'admin';
+$sessionData = $_SESSION[$adminSessionKey] ?? null;
+$isAuthenticated = is_array($sessionData)
+    ? (!empty($sessionData['authenticated']))
+    : ($sessionData === true);
+
+if (!$isAuthenticated) {
     header('Location: login.php');
     exit;
 }
@@ -23,148 +30,16 @@ if (isset($_GET['debug'])) {
     @error_reporting(E_ALL);
 }
 
-// --- Daten und Filter vorbereiten ---
-$stats = [];
-$logs  = [];
-$byHour = [];
-$byDay  = [];
-$byDow  = [];
-$totals = ['total'=>0,'empty'=>0,'avg_q_len'=>0,'avg_a_len'=>0];
-$fatalError = null;
+$analysisFilters = analytics_normalize_filters($_GET);
 
-// Filter
-$start = isset($_GET['start']) ? trim($_GET['start']) : '';
-$end   = isset($_GET['end'])   ? trim($_GET['end'])   : '';
-$q     = isset($_GET['q'])     ? trim($_GET['q'])     : '';
-$limit = isset($_GET['limit']) ? (int)$_GET['limit']  : 100;
-if ($limit < 10 || $limit > 1000) { $limit = 100; }
-
-// WHERE-Klausel aufbauen (SQLite)
-$where = [];
-$params = [];
-if ($start !== '') { $where[] = "time >= :start"; $params[':start'] = $start . ' 00:00:00'; }
-if ($end   !== '') { $where[] = "time <= :end";   $params[':end']   = $end   . ' 23:59:59'; }
-if ($q     !== '') { $where[] = "question LIKE :q"; $params[':q'] = '%' . $q . '%'; }
-$whereSql = $where ? ('WHERE ' . implode(' AND ', $where)) : '';
-
-// CSV-Export
-if (isset($_GET['export']) && $_GET['export'] === 'csv' && isset($db) && $db instanceof PDO) {
-    header('Content-Type: text/csv; charset=utf-8');
-    header('Content-Disposition: attachment; filename="chat_logs.csv"');
-    $out = fopen('php://output', 'w');
-    fputcsv($out, ['time','question','answer']);
-    $sqlExport = "SELECT time, question, answer FROM logs $whereSql ORDER BY time DESC LIMIT 10000";
-    $stmtE = $db->prepare($sqlExport);
-    foreach ($params as $k => $v) { $stmtE->bindValue($k, $v); }
-    $stmtE->execute();
-    while ($row = $stmtE->fetch(PDO::FETCH_ASSOC)) {
-        fputcsv($out, [$row['time'], $row['question'], $row['answer']]);
-    }
-    fclose($out);
-    exit;
+if (isset($_GET['export']) && $_GET['export'] === 'csv') {
+    analytics_export_csv($db ?? null, $analysisFilters);
 }
 
-// Export-URL mit aktiven Parametern
-$queryParams = http_build_query(array_filter([
-    'start' => $start,
-    'end'   => $end,
-    'q'     => $q,
-    'limit' => $limit
-], function($v){ return $v !== null && $v !== ''; }));
-$exportUrl = $_SERVER['PHP_SELF'] . '?' . ($queryParams ? ($queryParams . '&') : '') . 'export=csv';
-
-// --- SQLite-Funktionsalias / Formatierung ---
-// time: TEXT/DATETIME kompatibel
-$fnDate = "strftime('%Y-%m-%d', time)";               // Tagesaggregation
-$fnHour = "CAST(strftime('%H', time) AS INTEGER)";     // Stunde 0..23
-$fnDow  = "CAST(strftime('%w', time) AS INTEGER)";     // 0=So..6=Sa
-$fnQLen = "LENGTH(question)";
-$fnALen = "LENGTH(answer)";
-$dowIsSundayZero = true; // für die Anzeige
-
-// --- Datenbankabfragen ---
-if (isset($db) && $db instanceof PDO) {
-  try {
-    // Top 20 Fragen
-    $sqlTop = "SELECT question, COUNT(*) AS cnt
-               FROM logs
-               $whereSql
-               GROUP BY question
-               ORDER BY cnt DESC
-               LIMIT 20";
-    $stmtTop = $db->prepare($sqlTop);
-    foreach ($params as $k => $v) { $stmtTop->bindValue($k, $v); }
-    $stmtTop->execute();
-    $stats = $stmtTop->fetchAll(PDO::FETCH_ASSOC);
-
-    // Letzte Einträge
-    $sqlLast = "SELECT question, answer, time
-                FROM logs
-                $whereSql
-                ORDER BY time DESC
-                LIMIT :limit";
-    $stmtLast = $db->prepare($sqlLast);
-    foreach ($params as $k => $v) { $stmtLast->bindValue($k, $v); }
-    $stmtLast->bindValue(':limit', $limit, PDO::PARAM_INT);
-    $stmtLast->execute();
-    $logs = $stmtLast->fetchAll(PDO::FETCH_ASSOC);
-
-    // KPIs / Totals
-    $sqlTotals = "SELECT COUNT(*) AS total,
-                         SUM(CASE WHEN (answer IS NULL OR answer='') THEN 1 ELSE 0 END) AS empty_cnt,
-                         AVG($fnQLen) AS avg_q_len,
-                         AVG($fnALen) AS avg_a_len
-                  FROM logs
-                  $whereSql";
-    $stmtT = $db->prepare($sqlTotals);
-    foreach ($params as $k => $v) { $stmtT->bindValue($k, $v); }
-    $stmtT->execute();
-    $t = $stmtT->fetch(PDO::FETCH_ASSOC);
-    if ($t) {
-        $totals['total']     = (int)$t['total'];
-        $totals['empty']     = (int)$t['empty_cnt'];
-        $totals['avg_q_len'] = (int)round($t['avg_q_len']);
-        $totals['avg_a_len'] = (int)round($t['avg_a_len']);
-    }
-
-    // Stoßzeiten (Stunde)
-    $sqlHour = "SELECT $fnHour AS h, COUNT(*) AS cnt
-                FROM logs
-                $whereSql
-                GROUP BY $fnHour
-                ORDER BY h";
-    $stmtH = $db->prepare($sqlHour);
-    foreach ($params as $k => $v) { $stmtH->bindValue($k, $v); }
-    $stmtH->execute();
-    $byHour = $stmtH->fetchAll(PDO::FETCH_ASSOC);
-
-    // Verlauf je Tag (letzte 30 Tage)
-    $sqlDay = "SELECT $fnDate AS d, COUNT(*) AS cnt
-               FROM logs
-               $whereSql
-               GROUP BY $fnDate
-               ORDER BY d DESC
-               LIMIT 30";
-    $stmtD = $db->prepare($sqlDay);
-    foreach ($params as $k => $v) { $stmtD->bindValue($k, $v); }
-    $stmtD->execute();
-    $byDay = array_reverse($stmtD->fetchAll(PDO::FETCH_ASSOC)); // aufsteigend anzeigen
-
-    // Verteilung nach Wochentag
-    $sqlDow = "SELECT $fnDow AS dow, COUNT(*) AS cnt
-               FROM logs
-               $whereSql
-               GROUP BY $fnDow
-               ORDER BY dow";
-    $stmtW = $db->prepare($sqlDow);
-    foreach ($params as $k => $v) { $stmtW->bindValue($k, $v); }
-    $stmtW->execute();
-    $byDow = $stmtW->fetchAll(PDO::FETCH_ASSOC);
-
-  } catch (Throwable $ex) {
-    $fatalError = $ex->getMessage();
-  }
-}
+$analysisData = analytics_fetch_data($db ?? null, $analysisFilters);
+$queryString = analytics_query_string($analysisFilters);
+$exportUrl = $_SERVER['PHP_SELF'] . '?' . ($queryString ? ($queryString . '&') : '') . 'export=csv';
+$backLink = 'admin.php';
 ?>
 <!DOCTYPE html>
 <html lang="de">
@@ -175,155 +50,9 @@ if (isset($db) && $db instanceof PDO) {
     <link rel="stylesheet" href="<?php echo htmlspecialchars($coreRelative); ?>/assets/css/style.css">
 </head>
 <body class="analytics-page">
-  <div class="top-actions">
-    <h1>Analyse – <?php echo htmlspecialchars($HOTEL_NAME); ?></h1>
-    <div>
-      <a class="button" href="<?php echo htmlspecialchars($exportUrl); ?>">CSV exportieren</a>
-      <a class="button ghost" href="admin.php">Zurück</a>
-    </div>
-  </div>
-
-  <form method="get" class="filters">
-    <div class="field">
-      <label for="start" class="muted">Startdatum</label>
-      <input type="date" id="start" name="start" value="<?php echo htmlspecialchars($start); ?>">
-    </div>
-    <div class="field">
-      <label for="end" class="muted">Enddatum</label>
-      <input type="date" id="end" name="end" value="<?php echo htmlspecialchars($end); ?>">
-    </div>
-    <div class="field">
-      <label for="q" class="muted">Suche (Frage enthält)</label>
-      <input type="text" id="q" name="q" placeholder="z. B. Frühstück, Spa, Parkplatz" value="<?php echo htmlspecialchars($q); ?>">
-    </div>
-    <div class="field">
-      <label for="limit" class="muted">Anzahl letzter Einträge</label>
-      <input type="number" id="limit" name="limit" min="10" max="1000" step="10" value="<?php echo (int)$limit; ?>">
-    </div>
-    <div class="field">
-      <button type="submit">Filter anwenden</button>
-    </div>
-  </form>
-
-  <?php if (!empty($fatalError)): ?>
-    <div class="card span-12" style="border-color:#ef4444">
-      <h2 style="color:#ef8888;margin-top:0;">Fehler bei der Datenabfrage</h2>
-      <div class="muted"><?php echo htmlspecialchars($fatalError); ?></div>
-      <p class="muted">Tipp: Seite mit <code>?debug=1</code> aufrufen. (SQLite aktiv)</p>
-    </div>
-  <?php endif; ?>
-
-  <div class="grid">
-    <!-- KPIs -->
-    <div class="kpis">
-      <div class="kpi">
-        <div class="label">Gesamt</div>
-        <div class="value"><?php echo number_format($totals['total'], 0, ',', '.'); ?></div>
-      </div>
-      <div class="kpi">
-        <div class="label">Leere Antworten</div>
-        <div class="value" title="Antwort ist leer / nicht vorhanden">
-          <?php echo number_format($totals['empty'], 0, ',', '.'); ?>
-        </div>
-      </div>
-      <div class="kpi">
-        <div class="label">Ø Zeichen Frage</div>
-        <div class="value"><?php echo number_format($totals['avg_q_len'], 0, ',', '.'); ?></div>
-      </div>
-      <div class="kpi">
-        <div class="label">Ø Zeichen Antwort</div>
-        <div class="value"><?php echo number_format($totals['avg_a_len'], 0, ',', '.'); ?></div>
-      </div>
-    </div>
-
-    <!-- Verlauf letzte 30 Tage -->
-    <div class="card span-12">
-      <h2>Aktivitätsverlauf (letzte 30 Tage)</h2>
-      <table>
-        <thead><tr><th>Datum</th><th>Anfragen</th></tr></thead>
-        <tbody>
-          <?php foreach ($byDay as $row): ?>
-            <tr>
-              <td><?php echo htmlspecialchars($row['d']); ?></td>
-              <td><?php echo htmlspecialchars($row['cnt']); ?></td>
-            </tr>
-          <?php endforeach; ?>
-        </tbody>
-      </table>
-    </div>
-
-    <!-- Stoßzeiten nach Stunde -->
-    <div class="card span-6">
-      <h2>Stoßzeiten (Stunde des Tages)</h2>
-      <div class="bars">
-        <?php
-          $maxHour = 0;
-          foreach ($byHour as $r) { if ((int)$r['cnt'] > $maxHour) { $maxHour = (int)$r['cnt']; } }
-          foreach ($byHour as $r):
-            $w = $maxHour ? intval(((int)$r['cnt'] / $maxHour) * 100) : 0;
-        ?>
-          <div class="bar">
-            <div class="label"><?php echo str_pad((string)$r['h'], 2, '0', STR_PAD_LEFT) . ':00'; ?></div>
-            <div class="track"><div class="fill" style="width: <?php echo $w; ?>%"></div></div>
-            <div class="label"><?php echo (int)$r['cnt']; ?></div>
-          </div>
-        <?php endforeach; ?>
-      </div>
-    </div>
-
-    <!-- Wochentage -->
-    <div class="card span-6">
-      <h2>Verteilung nach Wochentag</h2>
-      <div class="bars">
-        <?php
-          $dowNames = [0=>'So',1=>'Mo',2=>'Di',3=>'Mi',4=>'Do',5=>'Fr',6=>'Sa'];
-          $maxDow = 0;
-          foreach ($byDow as $r) { if ((int)$r['cnt'] > $maxDow) { $maxDow = (int)$r['cnt']; } }
-          foreach ($byDow as $r):
-            $name = isset($dowNames[(int)$r['dow']]) ? $dowNames[(int)$r['dow']] : (string)$r['dow'];
-            $w = $maxDow ? intval(((int)$r['cnt'] / $maxDow) * 100) : 0;
-        ?>
-          <div class="bar">
-            <div class="label"><?php echo htmlspecialchars($name); ?></div>
-            <div class="track"><div class="fill" style="width: <?php echo $w; ?>%"></div></div>
-            <div class="label"><?php echo (int)$r['cnt']; ?></div>
-          </div>
-        <?php endforeach; ?>
-      </div>
-    </div>
-
-    <!-- Top 20 Fragen -->
-    <div class="card span-6">
-      <h2>Häufig gestellte Fragen (Top 20)</h2>
-      <table>
-        <thead><tr><th>Frage</th><th>Anzahl</th></tr></thead>
-        <tbody>
-          <?php foreach ($stats as $row): ?>
-            <tr>
-              <td><?php echo htmlspecialchars($row['question']); ?></td>
-              <td><?php echo htmlspecialchars($row['cnt']); ?></td>
-            </tr>
-          <?php endforeach; ?>
-        </tbody>
-      </table>
-    </div>
-
-    <!-- Letzte Anfragen -->
-    <div class="card span-6">
-      <h2>Letzte Anfragen</h2>
-      <table>
-        <thead><tr><th>Zeit</th><th>Frage</th><th>Antwort</th></tr></thead>
-        <tbody>
-          <?php foreach ($logs as $row): ?>
-            <tr>
-              <td><?php echo htmlspecialchars($row['time']); ?></td>
-              <td><?php echo htmlspecialchars($row['question']); ?></td>
-              <td><?php echo nl2br(htmlspecialchars($row['answer'])); ?></td>
-            </tr>
-          <?php endforeach; ?>
-        </tbody>
-      </table>
-    </div>
-  </div>
+<?php
+$analysisFilters['tab'] = 'analysis';
+include __DIR__ . '/partials/analysis_content.php';
+?>
 </body>
 </html>

--- a/core/analytics_helpers.php
+++ b/core/analytics_helpers.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Hilfsfunktionen zur Analyse der Chat-Logs.
+ */
+
+/**
+ * Normalisiert Filterparameter für die Analytics-Abfragen.
+ *
+ * @param array<string,mixed> $input
+ * @return array{start:string,end:string,q:string,limit:int}
+ */
+function analytics_normalize_filters(array $input): array
+{
+    $start = isset($input['start']) ? trim((string)$input['start']) : '';
+    $end   = isset($input['end'])   ? trim((string)$input['end'])   : '';
+    $q     = isset($input['q'])     ? trim((string)$input['q'])     : '';
+    $limit = isset($input['limit']) ? (int)$input['limit'] : 100;
+    if ($limit < 10 || $limit > 1000) {
+        $limit = 100;
+    }
+
+    return [
+        'start' => $start,
+        'end'   => $end,
+        'q'     => $q,
+        'limit' => $limit,
+    ];
+}
+
+/**
+ * Erstellt WHERE-Klausel und Parameter für die Filter.
+ *
+ * @param array{start:string,end:string,q:string,limit:int} $filters
+ * @return array{sql:string,params:array<string,string>}
+ */
+function analytics_build_where(array $filters): array
+{
+    $where = [];
+    $params = [];
+    if ($filters['start'] !== '') {
+        $where[] = "time >= :start";
+        $params[':start'] = $filters['start'] . ' 00:00:00';
+    }
+    if ($filters['end'] !== '') {
+        $where[] = "time <= :end";
+        $params[':end'] = $filters['end'] . ' 23:59:59';
+    }
+    if ($filters['q'] !== '') {
+        $where[] = "question LIKE :q";
+        $params[':q'] = '%' . $filters['q'] . '%';
+    }
+    $sql = $where ? ('WHERE ' . implode(' AND ', $where)) : '';
+
+    return ['sql' => $sql, 'params' => $params];
+}
+
+/**
+ * Führt alle notwendigen Datenbankabfragen aus und gibt die Ergebnisse zurück.
+ *
+ * @param PDO|null $db
+ * @param array{start:string,end:string,q:string,limit:int} $filters
+ * @return array{
+ *   stats:array<int,array<string,mixed>>,
+ *   logs:array<int,array<string,mixed>>,
+ *   byHour:array<int,array<string,mixed>>,
+ *   byDay:array<int,array<string,mixed>>,
+ *   byDow:array<int,array<string,mixed>>,
+ *   totals:array<string,int>,
+ *   fatalError:?string
+ * }
+ */
+function analytics_fetch_data(?PDO $db, array $filters): array
+{
+    $stats = [];
+    $logs  = [];
+    $byHour = [];
+    $byDay  = [];
+    $byDow  = [];
+    $totals = ['total'=>0,'empty'=>0,'avg_q_len'=>0,'avg_a_len'=>0];
+    $fatalError = null;
+
+    if (!$db instanceof PDO) {
+        return compact('stats', 'logs', 'byHour', 'byDay', 'byDow', 'totals', 'fatalError');
+    }
+
+    $parts = analytics_build_where($filters);
+    $whereSql = $parts['sql'];
+    $params = $parts['params'];
+
+    // SQLite spezifische Funktionen
+    $fnDate = "strftime('%Y-%m-%d', time)";
+    $fnHour = "CAST(strftime('%H', time) AS INTEGER)";
+    $fnDow  = "CAST(strftime('%w', time) AS INTEGER)";
+    $fnQLen = "LENGTH(question)";
+    $fnALen = "LENGTH(answer)";
+
+    try {
+        // Top-Fragen
+        $sqlTop = "SELECT question, COUNT(*) AS cnt
+                   FROM logs
+                   $whereSql
+                   GROUP BY question
+                   ORDER BY cnt DESC
+                   LIMIT 20";
+        $stmtTop = $db->prepare($sqlTop);
+        foreach ($params as $k => $v) { $stmtTop->bindValue($k, $v); }
+        $stmtTop->execute();
+        $stats = $stmtTop->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+        // Letzte Einträge
+        $sqlLast = "SELECT question, answer, time
+                    FROM logs
+                    $whereSql
+                    ORDER BY time DESC
+                    LIMIT :limit";
+        $stmtLast = $db->prepare($sqlLast);
+        foreach ($params as $k => $v) { $stmtLast->bindValue($k, $v); }
+        $stmtLast->bindValue(':limit', $filters['limit'], PDO::PARAM_INT);
+        $stmtLast->execute();
+        $logs = $stmtLast->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+        // Kennzahlen
+        $sqlTotals = "SELECT COUNT(*) AS total,
+                             SUM(CASE WHEN (answer IS NULL OR answer='') THEN 1 ELSE 0 END) AS empty_cnt,
+                             AVG($fnQLen) AS avg_q_len,
+                             AVG($fnALen) AS avg_a_len
+                      FROM logs
+                      $whereSql";
+        $stmtTotals = $db->prepare($sqlTotals);
+        foreach ($params as $k => $v) { $stmtTotals->bindValue($k, $v); }
+        $stmtTotals->execute();
+        $row = $stmtTotals->fetch(PDO::FETCH_ASSOC);
+        if ($row) {
+            $totals['total']     = (int)$row['total'];
+            $totals['empty']     = (int)$row['empty_cnt'];
+            $totals['avg_q_len'] = (int)round((float)$row['avg_q_len']);
+            $totals['avg_a_len'] = (int)round((float)$row['avg_a_len']);
+        }
+
+        // Stundenverteilung
+        $sqlHour = "SELECT $fnHour AS h, COUNT(*) AS cnt
+                    FROM logs
+                    $whereSql
+                    GROUP BY $fnHour
+                    ORDER BY h";
+        $stmtHour = $db->prepare($sqlHour);
+        foreach ($params as $k => $v) { $stmtHour->bindValue($k, $v); }
+        $stmtHour->execute();
+        $byHour = $stmtHour->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+        // Tagesverlauf
+        $sqlDay = "SELECT $fnDate AS d, COUNT(*) AS cnt
+                   FROM logs
+                   $whereSql
+                   GROUP BY $fnDate
+                   ORDER BY d DESC
+                   LIMIT 30";
+        $stmtDay = $db->prepare($sqlDay);
+        foreach ($params as $k => $v) { $stmtDay->bindValue($k, $v); }
+        $stmtDay->execute();
+        $byDay = array_reverse($stmtDay->fetchAll(PDO::FETCH_ASSOC) ?: []);
+
+        // Wochentage
+        $sqlDow = "SELECT $fnDow AS dow, COUNT(*) AS cnt
+                   FROM logs
+                   $whereSql
+                   GROUP BY $fnDow
+                   ORDER BY dow";
+        $stmtDow = $db->prepare($sqlDow);
+        foreach ($params as $k => $v) { $stmtDow->bindValue($k, $v); }
+        $stmtDow->execute();
+        $byDow = $stmtDow->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    } catch (Throwable $ex) {
+        $fatalError = $ex->getMessage();
+    }
+
+    return compact('stats', 'logs', 'byHour', 'byDay', 'byDow', 'totals', 'fatalError');
+}
+
+/**
+ * Gibt einen CSV-Export der Chat-Logs aus und beendet das Skript.
+ *
+ * @param PDO|null $db
+ * @param array{start:string,end:string,q:string,limit:int} $filters
+ * @return never
+ */
+function analytics_export_csv(?PDO $db, array $filters): void
+{
+    if (!$db instanceof PDO) {
+        header('Content-Type: text/plain; charset=utf-8');
+        echo "Keine Datenbankverbindung verfügbar.";
+        exit;
+    }
+
+    $parts = analytics_build_where($filters);
+    $whereSql = $parts['sql'];
+    $params = $parts['params'];
+
+    header('Content-Type: text/csv; charset=utf-8');
+    header('Content-Disposition: attachment; filename="chat_logs.csv"');
+
+    $out = fopen('php://output', 'w');
+    if ($out === false) {
+        exit;
+    }
+    fputcsv($out, ['time', 'question', 'answer']);
+
+    $sql = "SELECT time, question, answer
+            FROM logs
+            $whereSql
+            ORDER BY time DESC
+            LIMIT 10000";
+    $stmt = $db->prepare($sql);
+    foreach ($params as $k => $v) { $stmt->bindValue($k, $v); }
+    $stmt->execute();
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        fputcsv($out, [$row['time'], $row['question'], $row['answer']]);
+    }
+    fclose($out);
+    exit;
+}
+
+/**
+ * Baut eine Query-String-Repräsentation der Filter.
+ *
+ * @param array{start:string,end:string,q:string,limit:int} $filters
+ * @return string
+ */
+function analytics_query_string(array $filters): string
+{
+    $params = [];
+    foreach (['start','end','q','limit'] as $key) {
+        if ($filters[$key] !== '' && $filters[$key] !== null) {
+            $params[$key] = $filters[$key];
+        }
+    }
+    return http_build_query($params);
+}

--- a/core/assets/css/style.css
+++ b/core/assets/css/style.css
@@ -263,3 +263,118 @@ body {
   background:var(--accent); color:#fff;
 }
 .analytics-page .button.ghost{background:transparent; color:var(--text);}
+
+/* === Admin Dashboard === */
+.admin-dashboard {
+  --bg:#0f1115; --card:#151924; --muted:#8a93a6; --text:#e5e7ee; --accent:#3b82f6; --border:#232836;
+  min-height:100vh;
+  margin:0;
+  background:var(--bg);
+  color:var(--text);
+  font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,Helvetica,sans-serif;
+}
+
+.admin-dashboard a { color:var(--accent); }
+
+.admin-shell { max-width:1200px; margin:0 auto; padding:32px 24px 48px; display:flex; flex-direction:column; gap:24px; }
+
+.admin-header { display:flex; justify-content:space-between; align-items:flex-start; gap:16px; }
+.admin-header h1 { margin:0; font-size:28px; }
+.admin-header .muted { color:var(--muted); margin-top:6px; font-size:14px; }
+.admin-header .button { text-decoration:none; }
+
+.admin-dashboard .button {
+  display:inline-flex; align-items:center; justify-content:center;
+  padding:10px 16px; border-radius:8px; font-weight:600;
+  background:var(--accent); color:#fff; border:1px solid var(--border);
+  cursor:pointer; text-decoration:none;
+}
+.admin-dashboard .button:hover { filter:brightness(1.05); }
+.admin-dashboard .button.ghost { background:transparent; color:var(--text); }
+
+.tab-nav { display:flex; gap:12px; border-bottom:1px solid var(--border); padding-bottom:8px; }
+.tab-link {
+  padding:10px 16px; border-radius:10px 10px 0 0; text-decoration:none;
+  color:var(--muted); border:1px solid transparent; font-weight:600;
+}
+.tab-link:hover { color:var(--text); }
+.tab-link.active {
+  color:var(--text);
+  background:var(--card);
+  border-color:var(--border);
+  border-bottom-color:var(--card);
+}
+
+.tab-panels { display:flex; flex-direction:column; gap:24px; }
+.tab-panel { display:none; }
+.tab-panel.active { display:block; }
+
+.admin-dashboard .card {
+  background:var(--card);
+  border:1px solid var(--border);
+  border-radius:12px;
+  padding:24px;
+  box-shadow:0 10px 30px rgba(0,0,0,0.2);
+}
+
+.admin-dashboard .muted { color:var(--muted); }
+
+.stacked-form { display:flex; flex-direction:column; gap:16px; }
+.stacked-form textarea,
+.stacked-form input[type="text"],
+.stacked-form input[type="url"],
+.stacked-form input[type="password"] {
+  width:100%;
+  background:#0b0e14;
+  border:1px solid var(--border);
+  color:var(--text);
+  padding:10px 12px;
+  border-radius:8px;
+  font-size:15px;
+  box-sizing:border-box;
+}
+.stacked-form textarea { min-height:320px; font-family:monospace; line-height:1.5; }
+
+.admin-dashboard .grid.two-cols {
+  display:grid; gap:16px;
+  grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+}
+
+.admin-dashboard .field { display:flex; flex-direction:column; gap:6px; }
+.admin-dashboard .field > span { font-size:12px; color:var(--muted); text-transform:uppercase; letter-spacing:.08em; }
+.admin-dashboard .field.checkbox { flex-direction:row; align-items:center; gap:8px; }
+.admin-dashboard .field.checkbox span { text-transform:none; letter-spacing:0; font-size:14px; }
+
+.admin-dashboard .form-actions { display:flex; justify-content:flex-end; gap:12px; }
+.admin-dashboard .form-actions .primary,
+.admin-dashboard button.primary {
+  border:1px solid var(--border);
+  background:var(--accent);
+  color:#fff;
+  padding:10px 20px;
+  border-radius:8px;
+  font-weight:600;
+  cursor:pointer;
+}
+.admin-dashboard .form-actions .primary:hover,
+.admin-dashboard button.primary:hover { filter:brightness(1.05); }
+
+.admin-dashboard .flash {
+  border-radius:10px;
+  padding:12px 14px;
+  margin-bottom:12px;
+  border:1px solid var(--border);
+  background:rgba(59,130,246,0.12);
+  color:#dbeafe;
+}
+.admin-dashboard .flash.success { background:rgba(34,197,94,0.12); border-color:#22c55e; color:#bbf7d0; }
+.admin-dashboard .flash.error { background:rgba(239,68,68,0.12); border-color:#ef4444; color:#fecaca; }
+
+.admin-dashboard .account-list { display:flex; flex-direction:column; gap:16px; margin-top:16px; }
+.admin-dashboard .account-row { display:grid; gap:16px; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); align-items:flex-end; }
+.admin-dashboard .account-row .field.checkbox { align-items:center; justify-content:flex-start; }
+
+.admin-dashboard .add-account { margin-top:12px; }
+
+.admin-dashboard ul { margin:0 0 0 18px; }
+.admin-dashboard li { margin:4px 0; }

--- a/core/config.sample.php
+++ b/core/config.sample.php
@@ -20,10 +20,23 @@ $LOG_DB = __DIR__ . '/data/logs.sqlite';
 // URL der Haupt‑Hotel‑Website. Diese wird für den "Zurück zur Website"‑Link verwendet.
 $HOTEL_URL = 'https://www.example-hotel.de';
 
-// Administrativer Benutzername. Für den Zugriff auf das Backend (FAQ‑Editor/Analyse).
+// Administrativer Benutzername. Für den Zugriff auf das Backend (FAQ/Analyse/Einstellungen).
 $ADMIN_USER = 'admin';
 
 // Passwort‑Hash für den administrativen Zugang. Verwenden Sie password_hash() zur Generierung eines sicheren Hashes.
 $ADMIN_PASSWORD_HASH = password_hash('changeme', PASSWORD_DEFAULT);
 
+// Alternativ können mehrere Benutzer über $ADMIN_USERS hinterlegt werden (Benutzername + Passwort-Hash).
+// Die Administrationsoberfläche legt ansonsten eine data/admin_users.json an und verwaltet diese Datei.
+// $ADMIN_USERS = [
+//     [
+//         'username' => 'admin',
+//         'password_hash' => password_hash('changeme', PASSWORD_DEFAULT),
+//     ],
+// ];
+
 // Hinweis: Diese Datei ist nur ein Beispiel. Für jedes Hotel sollten Sie eine eigene config.php mit angepassten Werten anlegen.
+
+// Optional: Eindeutiger Schlüssel für das Hotel (z. B. für Session-Namespace).
+// Wird er nicht gesetzt, nutzt das System automatisch den Namen des Hotelordners.
+// $HOTEL_KEY = 'mein-hotel';

--- a/core/faq_editor.php
+++ b/core/faq_editor.php
@@ -10,81 +10,16 @@
 session_start();
 require_once __DIR__ . '/init.php';
 
-// Relativer Pfad zum Core‑Verzeichnis (vom Hotel‑Wrapper gesetzt)
-$coreRelative = $coreRelative ?? '.';
+$adminSessionKey = $ADMIN_SESSION_KEY ?? 'admin';
+$sessionData = $_SESSION[$adminSessionKey] ?? null;
+$isAuthenticated = is_array($sessionData)
+    ? (!empty($sessionData['authenticated']))
+    : ($sessionData === true);
 
-if (!isset($_SESSION['admin']) || $_SESSION['admin'] !== true) {
+if (!$isAuthenticated) {
     header('Location: login.php');
     exit;
 }
 
-$message = '';
-$currentContent = '';
-
-// FAQ‑Datei laden, falls vorhanden
-if (isset($FAQ_FILE) && file_exists($FAQ_FILE)) {
-    $currentContent = file_get_contents($FAQ_FILE);
-}
-
-// Bei POST speichern
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $newContent = $_POST['content'] ?? '';
-    if ($FAQ_FILE) {
-        file_put_contents($FAQ_FILE, $newContent);
-        $message = 'FAQ wurde erfolgreich gespeichert.';
-        $currentContent = $newContent;
-    }
-}
-?>
-<!DOCTYPE html>
-<html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <title>FAQ bearbeiten</title>
-    <!-- Gemeinsames Stylesheet aus dem Core einbinden -->
-    <link rel="stylesheet" href="<?php echo htmlspecialchars($coreRelative); ?>/assets/css/style.css">
-    <style>
-    body {
-        padding: 20px;
-        font-family: Arial, Helvetica, sans-serif;
-    }
-    textarea {
-        width: 100%;
-        height: 60vh;
-        font-family: monospace;
-        padding: 10px;
-        box-sizing: border-box;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-    }
-    button {
-        margin-top: 10px;
-        padding: 8px 12px;
-        background: #003366;
-        color: #fff;
-        border: none;
-        border-radius: 4px;
-        cursor: pointer;
-    }
-    button:hover {
-        background: #004080;
-    }
-    .message {
-        color: green;
-        margin-bottom: 10px;
-    }
-    </style>
-</head>
-<body>
-    <h1>FAQ bearbeiten – <?php echo htmlspecialchars($HOTEL_NAME); ?></h1>
-    <?php if ($message): ?>
-        <div class="message"><?php echo htmlspecialchars($message); ?></div>
-    <?php endif; ?>
-    <form method="post">
-        <textarea name="content"><?php echo htmlspecialchars($currentContent); ?></textarea>
-        <br>
-        <button type="submit">Speichern</button>
-    </form>
-    <p><a href="admin.php">Zurück zum Admin Bereich</a></p>
-</body>
-</html>
+header('Location: admin.php?tab=faq');
+exit;

--- a/core/init.php
+++ b/core/init.php
@@ -18,13 +18,42 @@ if (session_status() === PHP_SESSION_NONE) {
 
 // Ermitteln und Laden der Konfiguration
 if (isset($configPath) && file_exists($configPath)) {
+    $resolvedConfig = realpath($configPath);
     require $configPath;
 } elseif (file_exists(__DIR__ . '/../config.php')) {
     // Fallback für Entwicklungszwecke: lokale config.php im Projekt
+    $resolvedConfig = realpath(__DIR__ . '/../config.php');
     require __DIR__ . '/../config.php';
 } else {
     // Keine Konfiguration gefunden => Fehlermeldung ausgeben
     die('Konfigurationsdatei nicht gefunden. Bitte setzen Sie $configPath vor dem Einbinden von init.php.');
+}
+
+// Basisverzeichnis des Hotels und Pfad zur Konfiguration verfügbar machen
+if (!isset($HOTEL_BASE_PATH) || !is_string($HOTEL_BASE_PATH) || $HOTEL_BASE_PATH === '') {
+    if (isset($resolvedConfig) && $resolvedConfig !== false) {
+        $HOTEL_BASE_PATH = dirname($resolvedConfig);
+    } else {
+        $HOTEL_BASE_PATH = dirname(__DIR__);
+    }
+}
+
+if (!isset($HOTEL_CONFIG_PATH) || !is_string($HOTEL_CONFIG_PATH) || $HOTEL_CONFIG_PATH === '') {
+    $HOTEL_CONFIG_PATH = isset($resolvedConfig) && $resolvedConfig !== false ? $resolvedConfig : null;
+}
+
+// Eindeutigen Schlüssel für das Hotel ableiten (Konfiguration kann optional $HOTEL_KEY setzen)
+if (!isset($HOTEL_KEY) || !is_string($HOTEL_KEY) || $HOTEL_KEY === '') {
+    if (isset($resolvedConfig) && $resolvedConfig !== false) {
+        $HOTEL_KEY = basename(dirname($resolvedConfig));
+    } else {
+        $HOTEL_KEY = 'default';
+    }
+}
+
+// Session-Namespace für die Admin-Authentifizierung vorbereiten
+if (!isset($ADMIN_SESSION_KEY) || !is_string($ADMIN_SESSION_KEY) || $ADMIN_SESSION_KEY === '') {
+    $ADMIN_SESSION_KEY = 'admin_auth_' . hash('sha256', $HOTEL_KEY);
 }
 
 // Einrichtung der SQLite‑Datenbank für die Protokollierung

--- a/core/logout.php
+++ b/core/logout.php
@@ -1,10 +1,23 @@
 <?php
 /**
- * Beendet die Administrator‑Session und leitet zum Login zurück.
+ * Beendet ausschließlich die Administrator-Session des aktuellen Hotels
+ * und leitet anschließend zur Login-Seite zurück.
  */
 
+$configPath = $configPath ?? null;
+
 session_start();
-session_unset();
-session_destroy();
+require_once __DIR__ . '/init.php';
+
+$adminSessionKey = $ADMIN_SESSION_KEY ?? 'admin';
+
+if (isset($_SESSION[$adminSessionKey])) {
+    unset($_SESSION[$adminSessionKey]);
+}
+
+// Session-Fixation vorbeugen
+session_regenerate_id(true);
+
 header('Location: login.php');
 exit;
+

--- a/core/partials/analysis_content.php
+++ b/core/partials/analysis_content.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Gemeinsamer Markup-Teil für die Analyse-Ansicht.
+ *
+ * Erwartet die Variablen:
+ * - $analysisFilters (array)
+ * - $analysisData (array)
+ * - $exportUrl (string)
+ * - $coreRelative (string)
+ * - $HOTEL_NAME (string)
+ * - $backLink (string|null)
+ */
+?>
+<div class="analytics-page">
+  <div class="top-actions">
+    <h1>Analyse – <?php echo htmlspecialchars($HOTEL_NAME); ?></h1>
+    <div>
+      <a class="button" href="<?php echo htmlspecialchars($exportUrl); ?>">CSV exportieren</a>
+      <?php if (!empty($backLink)): ?>
+        <a class="button ghost" href="<?php echo htmlspecialchars($backLink); ?>">Zurück</a>
+      <?php endif; ?>
+    </div>
+  </div>
+
+  <form method="get" class="filters">
+    <?php if (isset($analysisFilters['tab'])): ?>
+      <input type="hidden" name="tab" value="<?php echo htmlspecialchars($analysisFilters['tab']); ?>">
+    <?php endif; ?>
+    <div class="field">
+      <label for="start" class="muted">Startdatum</label>
+      <input type="date" id="start" name="start" value="<?php echo htmlspecialchars($analysisFilters['start']); ?>">
+    </div>
+    <div class="field">
+      <label for="end" class="muted">Enddatum</label>
+      <input type="date" id="end" name="end" value="<?php echo htmlspecialchars($analysisFilters['end']); ?>">
+    </div>
+    <div class="field">
+      <label for="q" class="muted">Suche (Frage enthält)</label>
+      <input type="text" id="q" name="q" placeholder="z. B. Frühstück, Spa, Parkplatz" value="<?php echo htmlspecialchars($analysisFilters['q']); ?>">
+    </div>
+    <div class="field">
+      <label for="limit" class="muted">Anzahl letzter Einträge</label>
+      <input type="number" id="limit" name="limit" min="10" max="1000" step="10" value="<?php echo (int)$analysisFilters['limit']; ?>">
+    </div>
+    <div class="field">
+      <button type="submit">Filter anwenden</button>
+    </div>
+  </form>
+
+  <?php if (!empty($analysisData['fatalError'])): ?>
+    <div class="card span-12" style="border-color:#ef4444">
+      <h2 style="color:#ef8888;margin-top:0;">Fehler bei der Datenabfrage</h2>
+      <div class="muted"><?php echo htmlspecialchars($analysisData['fatalError']); ?></div>
+      <p class="muted">Tipp: Seite mit <code>?debug=1</code> aufrufen. (SQLite aktiv)</p>
+    </div>
+  <?php endif; ?>
+
+  <div class="grid">
+    <div class="kpis">
+      <div class="kpi">
+        <div class="label">Gesamt</div>
+        <div class="value"><?php echo number_format($analysisData['totals']['total'] ?? 0, 0, ',', '.'); ?></div>
+      </div>
+      <div class="kpi">
+        <div class="label">Leere Antworten</div>
+        <div class="value" title="Antwort ist leer / nicht vorhanden">
+          <?php echo number_format($analysisData['totals']['empty'] ?? 0, 0, ',', '.'); ?>
+        </div>
+      </div>
+      <div class="kpi">
+        <div class="label">Ø Zeichen Frage</div>
+        <div class="value"><?php echo number_format($analysisData['totals']['avg_q_len'] ?? 0, 0, ',', '.'); ?></div>
+      </div>
+      <div class="kpi">
+        <div class="label">Ø Zeichen Antwort</div>
+        <div class="value"><?php echo number_format($analysisData['totals']['avg_a_len'] ?? 0, 0, ',', '.'); ?></div>
+      </div>
+    </div>
+
+    <div class="card span-12">
+      <h2>Aktivitätsverlauf (letzte 30 Tage)</h2>
+      <table>
+        <thead><tr><th>Datum</th><th>Anfragen</th></tr></thead>
+        <tbody>
+          <?php foreach ($analysisData['byDay'] as $row): ?>
+            <tr>
+              <td><?php echo htmlspecialchars($row['d']); ?></td>
+              <td><?php echo htmlspecialchars($row['cnt']); ?></td>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="card span-6">
+      <h2>Stoßzeiten (Stunde des Tages)</h2>
+      <div class="bars">
+        <?php
+          $maxHour = 0;
+          foreach ($analysisData['byHour'] as $r) { if ((int)$r['cnt'] > $maxHour) { $maxHour = (int)$r['cnt']; } }
+          foreach ($analysisData['byHour'] as $r):
+            $w = $maxHour ? intval(((int)$r['cnt'] / $maxHour) * 100) : 0;
+        ?>
+          <div class="bar">
+            <div class="label"><?php echo str_pad((string)$r['h'], 2, '0', STR_PAD_LEFT) . ':00'; ?></div>
+            <div class="track"><div class="fill" style="width: <?php echo $w; ?>%"></div></div>
+            <div class="label"><?php echo (int)$r['cnt']; ?></div>
+          </div>
+        <?php endforeach; ?>
+      </div>
+    </div>
+
+    <div class="card span-6">
+      <h2>Verteilung nach Wochentag</h2>
+      <div class="bars">
+        <?php
+          $dowNames = [0=>'So',1=>'Mo',2=>'Di',3=>'Mi',4=>'Do',5=>'Fr',6=>'Sa'];
+          $maxDow = 0;
+          foreach ($analysisData['byDow'] as $r) { if ((int)$r['cnt'] > $maxDow) { $maxDow = (int)$r['cnt']; } }
+          foreach ($analysisData['byDow'] as $r):
+            $name = isset($dowNames[(int)$r['dow']]) ? $dowNames[(int)$r['dow']] : (string)$r['dow'];
+            $w = $maxDow ? intval(((int)$r['cnt'] / $maxDow) * 100) : 0;
+        ?>
+          <div class="bar">
+            <div class="label"><?php echo htmlspecialchars($name); ?></div>
+            <div class="track"><div class="fill" style="width: <?php echo $w; ?>%"></div></div>
+            <div class="label"><?php echo (int)$r['cnt']; ?></div>
+          </div>
+        <?php endforeach; ?>
+      </div>
+    </div>
+
+    <div class="card span-6">
+      <h2>Häufig gestellte Fragen (Top 20)</h2>
+      <table>
+        <thead><tr><th>Frage</th><th>Anzahl</th></tr></thead>
+        <tbody>
+          <?php foreach ($analysisData['stats'] as $row): ?>
+            <tr>
+              <td><?php echo htmlspecialchars($row['question']); ?></td>
+              <td><?php echo htmlspecialchars($row['cnt']); ?></td>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="card span-6">
+      <h2>Letzte Anfragen</h2>
+      <table>
+        <thead><tr><th>Zeit</th><th>Frage</th><th>Antwort</th></tr></thead>
+        <tbody>
+          <?php foreach ($analysisData['logs'] as $row): ?>
+            <tr>
+              <td><?php echo htmlspecialchars($row['time']); ?></td>
+              <td><?php echo htmlspecialchars($row['question']); ?></td>
+              <td><?php echo nl2br(htmlspecialchars($row['answer'])); ?></td>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- replace the simple admin link list with a tabbed dashboard that embeds the analytics view, FAQ editor and a new settings panel for hotel metadata and admin accounts
- add helpers to compute analytics data once, persist admin users in a per-hotel JSON file, and expose hotel base/config paths so the login can validate multiple accounts
- restyle the admin area, redirect the legacy FAQ editor, and update the sample config to document multi-user storage

## Testing
- php -l core/admin.php
- php -l core/analysis.php
- php -l core/login.php
- php -l core/init.php
- php -l core/faq_editor.php
- php -l core/admin_accounts.php
- php -l core/analytics_helpers.php
- php -l core/partials/analysis_content.php

------
https://chatgpt.com/codex/tasks/task_e_68ce9996100083249e6be8ea9a1c15d7