### PR TITLE
Refactor hotel wrappers to shared dispatcher

### DIFF
--- a/aarnhoog/admin.php
+++ b/aarnhoog/admin.php
@@ -1,5 +1,3 @@
 <?php
-// Admin‑Bereich für Aarnhoog
-$configPath  = __DIR__ . '/config.php';
-$coreRelative = '../core';
-require __DIR__ . '/../core/admin.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/aarnhoog/analysis.php
+++ b/aarnhoog/analysis.php
@@ -1,5 +1,3 @@
 <?php
-// Analyse der Chatlogs für Aarnhoog
-$configPath  = __DIR__ . '/config.php';
-$coreRelative = '../core';
-require __DIR__ . '/../core/analysis.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/aarnhoog/chat.php
+++ b/aarnhoog/chat.php
@@ -1,4 +1,3 @@
 <?php
-// Weiterleitung zur Chat‑Verarbeitung für Aarnhoog
-$configPath = __DIR__ . '/config.php';
-require __DIR__ . '/../core/chat.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/aarnhoog/faq_editor.php
+++ b/aarnhoog/faq_editor.php
@@ -1,5 +1,3 @@
 <?php
-// FAQ‑Editor für Aarnhoog
-$configPath  = __DIR__ . '/config.php';
-$coreRelative = '../core';
-require __DIR__ . '/../core/faq_editor.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/aarnhoog/index.php
+++ b/aarnhoog/index.php
@@ -1,6 +1,3 @@
 <?php
-// Einstiegspunkt für den Aarnhoog‑Chatbot
-$configPath  = __DIR__ . '/config.php';
-$coreRelative = '../core';
-$hotelCssUrl = 'assets/css/hotel.css';
-require __DIR__ . '/../core/index.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/aarnhoog/login.php
+++ b/aarnhoog/login.php
@@ -1,5 +1,3 @@
 <?php
-// Loginseite für Aarnhoog‑Admin
-$configPath  = __DIR__ . '/config.php';
-$coreRelative = '../core';
-require __DIR__ . '/../core/login.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/aarnhoog/logout.php
+++ b/aarnhoog/logout.php
@@ -1,4 +1,3 @@
 <?php
-// Logout des Aarnhoog‑Admins
-$configPath = __DIR__ . '/config.php';
-require __DIR__ . '/../core/logout.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/aarnhoog/privacy.php
+++ b/aarnhoog/privacy.php
@@ -1,7 +1,3 @@
 <?php
-$configPath   = __DIR__ . '/config.php';
-$coreRelative = '../core';
-$hotelCssUrl  = 'assets/css/hotel.css';
-$chatReturnUrl = 'index.php';
 
-require __DIR__ . '/../core/privacy.php';
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/core/hotel_dispatch.php
+++ b/core/hotel_dispatch.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Gemeinsamer Einstiegspunkt für alle hotelspezifischen Wrapper-Dateien.
+ *
+ * Das Skript ermittelt anhand der aufgerufenen Datei, welche Core-Komponente
+ * geladen werden soll, und stellt zuvor wiederkehrende Variablen bereit.
+ */
+
+$scriptFilename = $_SERVER['SCRIPT_FILENAME'] ?? null;
+if ($scriptFilename === null || !is_file($scriptFilename)) {
+    $includedFiles = get_included_files();
+    if (!empty($includedFiles)) {
+        $scriptFilename = $includedFiles[0];
+    }
+}
+
+if ($scriptFilename === null || !is_file($scriptFilename)) {
+    http_response_code(500);
+    echo 'Hotel-Dispatcher konnte die aufgerufene Datei nicht ermitteln.';
+    exit;
+}
+
+$scriptBasename = basename($scriptFilename);
+$hotelDirectory = dirname($scriptFilename);
+
+$configPath = $hotelDirectory . '/config.php';
+$coreRelative = '../core';
+
+if ($scriptBasename === 'privacy.php' && !isset($chatReturnUrl)) {
+    $chatReturnUrl = 'index.php';
+}
+
+$defaultHotelCss = 'assets/css/hotel.css';
+if (!isset($hotelCssUrl) && is_file($hotelDirectory . '/' . $defaultHotelCss)) {
+    $hotelCssUrl = $defaultHotelCss;
+}
+
+$scriptMap = [
+    'admin.php'      => 'admin.php',
+    'analysis.php'   => 'analysis.php',
+    'chat.php'       => 'chat.php',
+    'faq_editor.php' => 'faq_editor.php',
+    'index.php'      => 'index.php',
+    'login.php'      => 'login.php',
+    'logout.php'     => 'logout.php',
+    'privacy.php'    => 'privacy.php',
+];
+
+if (!isset($scriptMap[$scriptBasename])) {
+    http_response_code(404);
+    echo 'Unbekannte Seite.';
+    exit;
+}
+
+require __DIR__ . '/' . $scriptMap[$scriptBasename];
+

--- a/core/index.php
+++ b/core/index.php
@@ -14,6 +14,10 @@ require_once __DIR__ . '/init.php';
 // Hotel‑Wrapper (index.php) gesetzt. Fallback: '..' falls nicht gesetzt.
 $coreRelative = $coreRelative ?? '..';
 
+// Hotelspezifisches Stylesheet aus der Konfiguration übernehmen, falls der
+// Wrapper keine eigene Variable gesetzt hat.
+$hotelCssUrl = $hotelCssUrl ?? ($HOTEL_CSS_URL ?? null);
+
 // Ermitteln des relativen Pfads zum Logo innerhalb des Webservers
 $logoSrc = null;
 if (isset($LOGO_PATH) && file_exists($LOGO_PATH)) {

--- a/core/privacy.php
+++ b/core/privacy.php
@@ -11,6 +11,7 @@
 require_once __DIR__ . '/init.php';
 
 $coreRelative = $coreRelative ?? '..';
+$hotelCssUrl = $hotelCssUrl ?? ($HOTEL_CSS_URL ?? null);
 
 $logoSrc = null;
 if (isset($LOGO_PATH) && file_exists($LOGO_PATH)) {

--- a/faehrhaus/admin.php
+++ b/faehrhaus/admin.php
@@ -1,5 +1,3 @@
 <?php
-// Wrapper für den Admin‑Bereich des Fährhaus
-$configPath  = __DIR__ . '/config.php';
-$coreRelative = '../core';
-require __DIR__ . '/../core/admin.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/faehrhaus/analysis.php
+++ b/faehrhaus/analysis.php
@@ -1,5 +1,3 @@
 <?php
-// Analyse der Chatlogs für das Fährhaus
-$configPath  = __DIR__ . '/config.php';
-$coreRelative = '../core';
-require __DIR__ . '/../core/analysis.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/faehrhaus/chat.php
+++ b/faehrhaus/chat.php
@@ -1,4 +1,3 @@
 <?php
-// Weiterleitung zur Chat‑Verarbeitung für Fährhaus
-$configPath = __DIR__ . '/config.php';
-require __DIR__ . '/../core/chat.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/faehrhaus/faq_editor.php
+++ b/faehrhaus/faq_editor.php
@@ -1,5 +1,3 @@
 <?php
-// FAQ‑Editor für das Fährhaus
-$configPath  = __DIR__ . '/config.php';
-$coreRelative = '../core';
-require __DIR__ . '/../core/faq_editor.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/faehrhaus/index.php
+++ b/faehrhaus/index.php
@@ -1,8 +1,3 @@
 <?php
-// Einstiegspunkt für den Fährhaus‑Chatbot
-$configPath  = __DIR__ . '/config.php';
-// Relativer Pfad zum Core‑Verzeichnis aus Sicht dieses Scripts
-$coreRelative = '../core';
-// Optional: Pfad zur hotelspezifischen CSS-Datei, relativ zum Hotelordner
-$hotelCssUrl = 'assets/css/hotel.css';
-require __DIR__ . '/../core/index.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/faehrhaus/login.php
+++ b/faehrhaus/login.php
@@ -1,5 +1,3 @@
 <?php
-// Loginseite für den Fährhaus‑Admin
-$configPath  = __DIR__ . '/config.php';
-$coreRelative = '../core';
-require __DIR__ . '/../core/login.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/faehrhaus/logout.php
+++ b/faehrhaus/logout.php
@@ -1,4 +1,3 @@
 <?php
-// Logout des Fährhaus‑Admins
-$configPath = __DIR__ . '/config.php';
-require __DIR__ . '/../core/logout.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/faehrhaus/privacy.php
+++ b/faehrhaus/privacy.php
@@ -1,7 +1,3 @@
 <?php
-$configPath   = __DIR__ . '/config.php';
-$coreRelative = '../core';
-$hotelCssUrl  = 'assets/css/hotel.css';
-$chatReturnUrl = 'index.php';
 
-require __DIR__ . '/../core/privacy.php';
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/roth/admin.php
+++ b/roth/admin.php
@@ -1,4 +1,3 @@
 <?php
-$configPath  = __DIR__ . '/config.php';
-$coreRelative = '../core';
-require __DIR__ . '/../core/admin.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/roth/analysis.php
+++ b/roth/analysis.php
@@ -1,4 +1,3 @@
 <?php
-$configPath  = __DIR__ . '/config.php';
-$coreRelative = '../core';
-require __DIR__ . '/../core/analysis.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/roth/chat.php
+++ b/roth/chat.php
@@ -1,3 +1,3 @@
 <?php
-$configPath = __DIR__ . '/config.php';
-require __DIR__ . '/../core/chat.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/roth/faq_editor.php
+++ b/roth/faq_editor.php
@@ -1,4 +1,3 @@
 <?php
-$configPath  = __DIR__ . '/config.php';
-$coreRelative = '../core';
-require __DIR__ . '/../core/faq_editor.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/roth/index.php
+++ b/roth/index.php
@@ -1,5 +1,3 @@
 <?php
-$configPath  = __DIR__ . '/config.php';
-$coreRelative = '../core';
-$hotelCssUrl = 'assets/css/hotel.css';
-require __DIR__ . '/../core/index.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/roth/login.php
+++ b/roth/login.php
@@ -1,4 +1,3 @@
 <?php
-$configPath  = __DIR__ . '/config.php';
-$coreRelative = '../core';
-require __DIR__ . '/../core/login.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/roth/logout.php
+++ b/roth/logout.php
@@ -1,3 +1,3 @@
 <?php
-$configPath = __DIR__ . '/config.php';
-require __DIR__ . '/../core/logout.php';
+
+require __DIR__ . '/../core/hotel_dispatch.php';

--- a/roth/privacy.php
+++ b/roth/privacy.php
@@ -1,7 +1,3 @@
 <?php
-$configPath   = __DIR__ . '/config.php';
-$coreRelative = '../core';
-$hotelCssUrl  = 'assets/css/hotel.css';
-$chatReturnUrl = 'index.php';
 
-require __DIR__ . '/../core/privacy.php';
+require __DIR__ . '/../core/hotel_dispatch.php';


### PR DESCRIPTION
## Summary
- add a shared `core/hotel_dispatch.php` to bootstrap hotel entry points centrally
- update all tenant PHP entry files to load the new dispatcher instead of repeating configuration boilerplate
- let the core views reuse `$HOTEL_CSS_URL` or the default tenant stylesheet without per-file overrides

## Testing
- php -l core/hotel_dispatch.php
- php -l core/index.php
- php -l core/privacy.php
- for dir in aarnhoog faehrhaus roth; do for file in admin analysis chat faq_editor index login logout privacy; do php -l "${dir}/${file}.php"; done; done


------
https://chatgpt.com/codex/tasks/task_e_68d175ad14d88324a249b5fa99bee4a8