### PR TITLE
Allow configuring prompt and branding from settings

### DIFF
--- a/core/admin.php
+++ b/core/admin.php
@@ -111,10 +111,21 @@ if ($faqPath && is_readable($faqPath)) {
 $faqError = '';
 
 $settingsValues = [
-    'HOTEL_NAME' => isset($HOTEL_NAME) ? (string)$HOTEL_NAME : '',
-    'HOTEL_URL'  => isset($HOTEL_URL) ? (string)$HOTEL_URL : '',
-    'API_URL'    => isset($API_URL) ? (string)$API_URL : '',
-    'BOT_NAME'   => isset($BOT_NAME) ? (string)$BOT_NAME : '',
+    'HOTEL_NAME'                => isset($HOTEL_NAME) ? (string)$HOTEL_NAME : '',
+    'HOTEL_URL'                 => isset($HOTEL_URL) ? (string)$HOTEL_URL : '',
+    'BOT_NAME'                  => isset($BOT_NAME) ? (string)$BOT_NAME : 'Max',
+    'LOGO_PATH'                 => isset($LOGO_PATH) ? (string)$LOGO_PATH : '',
+    'BACKGROUND_IMAGE_URL'      => isset($BACKGROUND_IMAGE_URL) ? (string)$BACKGROUND_IMAGE_URL : '',
+    'CHAT_BACKGROUND_COLOR'     => isset($CHAT_BACKGROUND_COLOR) ? (string)$CHAT_BACKGROUND_COLOR : '#f0f0f0',
+    'CHAT_BOX_BACKGROUND_COLOR' => isset($CHAT_BOX_BACKGROUND_COLOR) ? (string)$CHAT_BOX_BACKGROUND_COLOR : '#808080',
+    'CHAT_PRIMARY_COLOR'        => isset($CHAT_PRIMARY_COLOR) ? (string)$CHAT_PRIMARY_COLOR : '#003366',
+    'CHAT_PRIMARY_TEXT_COLOR'   => isset($CHAT_PRIMARY_TEXT_COLOR) ? (string)$CHAT_PRIMARY_TEXT_COLOR : '#ffffff',
+    'CHAT_USER_BUBBLE_COLOR'    => isset($CHAT_USER_BUBBLE_COLOR) ? (string)$CHAT_USER_BUBBLE_COLOR : '#0078d7',
+    'CHAT_USER_TEXT_COLOR'      => isset($CHAT_USER_TEXT_COLOR) ? (string)$CHAT_USER_TEXT_COLOR : '#ffffff',
+    'CHAT_BOT_BUBBLE_COLOR'     => isset($CHAT_BOT_BUBBLE_COLOR) ? (string)$CHAT_BOT_BUBBLE_COLOR : '#f0f0f0',
+    'CHAT_BOT_TEXT_COLOR'       => isset($CHAT_BOT_TEXT_COLOR) ? (string)$CHAT_BOT_TEXT_COLOR : '#000000',
+    'CHAT_LINK_COLOR'           => isset($CHAT_LINK_COLOR) ? (string)$CHAT_LINK_COLOR : '#003366',
+    'PROMPT_EXTRA'              => isset($PROMPT_EXTRA) ? (string)$PROMPT_EXTRA : '',
 ];
 $settingsErrors = [];
 
@@ -354,12 +365,63 @@ $settingsFlash = admin_filter_flash($flashMessages, 'settings');
                 <input type="url" name="settings[HOTEL_URL]" value="<?php echo htmlspecialchars($settingsValues['HOTEL_URL']); ?>" placeholder="https://...">
               </label>
               <label class="field">
-                <span>API-Endpunkt</span>
-                <input type="url" name="settings[API_URL]" value="<?php echo htmlspecialchars($settingsValues['API_URL']); ?>" placeholder="https://...">
-              </label>
-              <label class="field">
                 <span>Bot-Name</span>
                 <input type="text" name="settings[BOT_NAME]" value="<?php echo htmlspecialchars($settingsValues['BOT_NAME']); ?>">
+              </label>
+              <label class="field">
+                <span>Logo-Pfad</span>
+                <input type="text" name="settings[LOGO_PATH]" value="<?php echo htmlspecialchars($settingsValues['LOGO_PATH']); ?>" placeholder="logo.png oder URL">
+              </label>
+            </div>
+            <label class="field">
+              <span>Zusätzliche Prompt-Anweisungen</span>
+              <textarea name="settings[PROMPT_EXTRA]" spellcheck="false"><?php echo htmlspecialchars($settingsValues['PROMPT_EXTRA']); ?></textarea>
+            </label>
+          </div>
+
+          <div class="card">
+            <h2>Design &amp; Branding</h2>
+            <p class="muted">Steuern Sie Hintergrundbild und Farbwerte. Relative Pfade beziehen sich auf den Hotelordner.</p>
+            <div class="grid two-cols">
+              <label class="field">
+                <span>Hintergrundbild (optional)</span>
+                <input type="text" name="settings[BACKGROUND_IMAGE_URL]" value="<?php echo htmlspecialchars($settingsValues['BACKGROUND_IMAGE_URL']); ?>" placeholder="assets/images/background.jpg">
+              </label>
+              <label class="field">
+                <span>Chat-Hintergrundfarbe</span>
+                <input type="color" name="settings[CHAT_BACKGROUND_COLOR]" value="<?php echo htmlspecialchars($settingsValues['CHAT_BACKGROUND_COLOR']); ?>">
+              </label>
+              <label class="field">
+                <span>Chatbox-Farbe</span>
+                <input type="color" name="settings[CHAT_BOX_BACKGROUND_COLOR]" value="<?php echo htmlspecialchars($settingsValues['CHAT_BOX_BACKGROUND_COLOR']); ?>">
+              </label>
+              <label class="field">
+                <span>Primärfarbe (Buttons &amp; Links)</span>
+                <input type="color" name="settings[CHAT_PRIMARY_COLOR]" value="<?php echo htmlspecialchars($settingsValues['CHAT_PRIMARY_COLOR']); ?>">
+              </label>
+              <label class="field">
+                <span>Primäre Textfarbe</span>
+                <input type="color" name="settings[CHAT_PRIMARY_TEXT_COLOR]" value="<?php echo htmlspecialchars($settingsValues['CHAT_PRIMARY_TEXT_COLOR']); ?>">
+              </label>
+              <label class="field">
+                <span>Benutzer-Blasenfarbe</span>
+                <input type="color" name="settings[CHAT_USER_BUBBLE_COLOR]" value="<?php echo htmlspecialchars($settingsValues['CHAT_USER_BUBBLE_COLOR']); ?>">
+              </label>
+              <label class="field">
+                <span>Benutzer-Textfarbe</span>
+                <input type="color" name="settings[CHAT_USER_TEXT_COLOR]" value="<?php echo htmlspecialchars($settingsValues['CHAT_USER_TEXT_COLOR']); ?>">
+              </label>
+              <label class="field">
+                <span>Bot-Blasenfarbe</span>
+                <input type="color" name="settings[CHAT_BOT_BUBBLE_COLOR]" value="<?php echo htmlspecialchars($settingsValues['CHAT_BOT_BUBBLE_COLOR']); ?>">
+              </label>
+              <label class="field">
+                <span>Bot-Textfarbe</span>
+                <input type="color" name="settings[CHAT_BOT_TEXT_COLOR]" value="<?php echo htmlspecialchars($settingsValues['CHAT_BOT_TEXT_COLOR']); ?>">
+              </label>
+              <label class="field">
+                <span>Linkfarbe</span>
+                <input type="color" name="settings[CHAT_LINK_COLOR]" value="<?php echo htmlspecialchars($settingsValues['CHAT_LINK_COLOR']); ?>">
               </label>
             </div>
           </div>

--- a/core/assets/css/style.css
+++ b/core/assets/css/style.css
@@ -6,16 +6,26 @@
  * CSS‑Dateien eingebunden oder dieser Datei angehängt werden.
  */
 
+:root {
+  --chat-background-color: #f0f0f0;
+  --chat-box-background-color: #808080;
+  --chat-primary-color: #003366;
+  --chat-primary-text-color: #ffffff;
+  --chat-link-color: var(--chat-primary-color);
+  --chat-user-bubble-color: #0078d7;
+  --chat-user-text-color: #ffffff;
+  --chat-bot-bubble-color: #f0f0f0;
+  --chat-bot-text-color: #000000;
+}
+
 html, body {
   height: 100%;
   margin: 0;
   font-family: Arial, Helvetica, sans-serif;
 }
 
-/* Hintergrundbild – kann in der Konfiguration durch ein anderes Bild ersetzt werden */
 body {
-  background: #f0f0f0;
-  /* Ein optionales Hintergrundbild kann über CSS oder im HTML gesetzt werden */
+  background: var(--chat-background-color);
   background-size: cover;
   background-position: center;
 }
@@ -40,7 +50,7 @@ body {
   max-width: 500px;
   height: 100%;
   max-height: 80vh;
-  background: grey;
+  background: var(--chat-box-background-color);
   border-radius: 12px;
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.25);
   padding: 20px;
@@ -76,20 +86,21 @@ body {
 
 .message.user {
   text-align: right;
-  color: #003366;
+  color: var(--chat-primary-color);
 }
 
 .message.bot {
   text-align: left;
-  color: #333;
+  color: var(--chat-bot-text-color);
 }
 
 #typing-indicator .bubble {
   font-style: italic;
-  color: #666;
-  background: #f0f0f0;
+  color: var(--chat-bot-text-color);
+  background: var(--chat-bot-bubble-color);
   border-radius: 14px;
   padding: 8px 12px;
+  opacity: 0.85;
 }
 
 .chat-controls input[type="text"] {
@@ -113,7 +124,7 @@ body {
 }
 
 .chat-controls .privacy a {
-  color: #003366;
+  color: var(--chat-primary-color);
   font-weight: 600;
   text-decoration: underline;
 }
@@ -126,8 +137,8 @@ body {
   padding: 8px;
   border: none;
   border-radius: 4px;
-  background: #003366;
-  color: #fff;
+  background: var(--chat-primary-color);
+  color: var(--chat-primary-text-color);
   cursor: pointer;
   font-size: 1em;
 }
@@ -199,7 +210,7 @@ body {
 }
 
 .privacy-box .privacy-content a {
-  color: #0f4c81;
+  color: var(--chat-link-color);
   text-decoration: underline;
 }
 
@@ -217,8 +228,8 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: #003366;
-  color: #ffffff;
+  background: var(--chat-primary-color);
+  color: var(--chat-primary-text-color);
   padding: 10px 18px;
   border-radius: 6px;
   text-decoration: none;
@@ -227,7 +238,7 @@ body {
 }
 
 .privacy-footer .privacy-back:hover {
-  background: #00264d;
+  filter: brightness(0.9);
 }
 
 @media (max-width: 600px) {
@@ -272,8 +283,8 @@ body {
   justify-content: flex-start;
 }
 .msg.bot .bubble {
-  background: #f0f0f0;
-  color: #000;
+  background: var(--chat-bot-bubble-color);
+  color: var(--chat-bot-text-color);
   border-top-left-radius: 0;
 }
 
@@ -282,8 +293,8 @@ body {
   justify-content: flex-end;
 }
 .msg.user .bubble {
-  background: #0078d7;
-  color: #fff;
+  background: var(--chat-user-bubble-color);
+  color: var(--chat-user-text-color);
   border-top-right-radius: 0;
   text-align: right;
 }
@@ -431,7 +442,8 @@ body {
 .stacked-form textarea,
 .stacked-form input[type="text"],
 .stacked-form input[type="url"],
-.stacked-form input[type="password"] {
+.stacked-form input[type="password"],
+.stacked-form input[type="color"] {
   width:100%;
   background:#0b0e14;
   border:1px solid var(--border);
@@ -442,6 +454,7 @@ body {
   box-sizing:border-box;
 }
 .stacked-form textarea { min-height:320px; font-family:monospace; line-height:1.5; }
+.stacked-form input[type="color"] { padding:0; min-height:42px; }
 
 .admin-dashboard .grid.two-cols {
   display:grid; gap:16px;

--- a/core/config.sample.php
+++ b/core/config.sample.php
@@ -11,6 +11,26 @@ $HOTEL_NAME = 'Hotel Name';
 // Pfad zum Hotellogo. Für die meisten Konfigurationen relativ zum Hotelverzeichnis, z. B. __DIR__.'/logo.png'.
 $LOGO_PATH = __DIR__ . '/logo.png';
 
+// Optional: Eigene Bezeichnung für den Bot (erscheint in den Chatblasen).
+$BOT_NAME = 'Max';
+
+// Optional: Relativer Pfad zu einer zusätzlichen CSS-Datei für individuelle Styles.
+$HOTEL_CSS_URL = 'assets/css/hotel.css';
+
+// Optional: Bild für den Seitenhintergrund. Relativ zum Hotelordner oder als URL.
+$BACKGROUND_IMAGE_URL = '';
+
+// Farbwerte für das Standard-Layout. Sie können hier oder im Admin-Bereich angepasst werden.
+$CHAT_BACKGROUND_COLOR      = '#f0f0f0';
+$CHAT_BOX_BACKGROUND_COLOR  = '#808080';
+$CHAT_PRIMARY_COLOR         = '#003366';
+$CHAT_PRIMARY_TEXT_COLOR    = '#ffffff';
+$CHAT_USER_BUBBLE_COLOR     = '#0078d7';
+$CHAT_USER_TEXT_COLOR       = '#ffffff';
+$CHAT_BOT_BUBBLE_COLOR      = '#f0f0f0';
+$CHAT_BOT_TEXT_COLOR        = '#000000';
+$CHAT_LINK_COLOR            = '#003366';
+
 // Pfad zur FAQ‑Markdown‑Datei, die die Wissensbasis für das Hotel enthält.
 $FAQ_FILE = __DIR__ . '/data/faq.md';
 
@@ -36,6 +56,9 @@ $ADMIN_PASSWORD_HASH = password_hash('changeme', PASSWORD_DEFAULT);
 // ];
 
 // Hinweis: Diese Datei ist nur ein Beispiel. Für jedes Hotel sollten Sie eine eigene config.php mit angepassten Werten anlegen.
+
+// Optional: Zusätzliche Anweisungen für das System-Prompt des Chatbots.
+$PROMPT_EXTRA = '';
 
 // Optional: Eindeutiger Schlüssel für das Hotel (z. B. für Session-Namespace).
 // Wird er nicht gesetzt, nutzt das System automatisch den Namen des Hotelordners.

--- a/core/index.php
+++ b/core/index.php
@@ -15,16 +15,7 @@ require_once __DIR__ . '/init.php';
 $coreRelative = $coreRelative ?? '..';
 
 // Ermitteln des relativen Pfads zum Logo innerhalb des Webservers
-$logoSrc = null;
-if (isset($LOGO_PATH) && file_exists($LOGO_PATH)) {
-    // basename() sorgt dafür, dass nur der Dateiname im <img> verwendet wird
-    $logoSrc = basename($LOGO_PATH);
-}
-
-// Hintergrund optional setzen: Falls im Hotellogo eine zusätzliche Bilddatei
-// vorhanden sein sollte, kann sie in CSS oder per Inline‑Style referenziert
-// werden. Hier laden wir kein spezielles Bild, sondern überlassen es dem
-// Benutzer, dies anzupassen.
+$logoSrc = chatbot_asset_url($LOGO_PATH ?? null, $HOTEL_BASE_PATH ?? null);
 ?>
 <!DOCTYPE html>
 <html lang="de">
@@ -46,13 +37,8 @@ if (isset($LOGO_PATH) && file_exists($LOGO_PATH)) {
     if (isset($hotelCssUrl) && $hotelCssUrl) {
         echo '<link rel="stylesheet" href="' . htmlspecialchars($hotelCssUrl) . '">';
     }
+    include __DIR__ . '/partials/style_overrides.php';
     ?>
-    <style>
-    /* Optionaler Inline‑Hintergrund: kann in der hotelspezifischen config überschrieben werden */
-    body {
-        background-image: url('<?php echo htmlspecialchars($coreRelative); ?>/assets/images/background.jpg');
-    }
-    </style>
 </head>
 <body>
     <div class="chat-overlay">

--- a/core/partials/style_overrides.php
+++ b/core/partials/style_overrides.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Gibt dynamische Style-Overrides aus, die über die Konfiguration gesetzt werden können.
+ */
+$styleVariables = [];
+$colorMap = [
+    'CHAT_BACKGROUND_COLOR'     => '--chat-background-color',
+    'CHAT_BOX_BACKGROUND_COLOR' => '--chat-box-background-color',
+    'CHAT_PRIMARY_COLOR'        => '--chat-primary-color',
+    'CHAT_PRIMARY_TEXT_COLOR'   => '--chat-primary-text-color',
+    'CHAT_USER_BUBBLE_COLOR'    => '--chat-user-bubble-color',
+    'CHAT_USER_TEXT_COLOR'      => '--chat-user-text-color',
+    'CHAT_BOT_BUBBLE_COLOR'     => '--chat-bot-bubble-color',
+    'CHAT_BOT_TEXT_COLOR'       => '--chat-bot-text-color',
+    'CHAT_LINK_COLOR'           => '--chat-link-color',
+];
+
+foreach ($colorMap as $configKey => $cssVar) {
+    if (isset($$configKey) && is_string($$configKey) && $$configKey !== '') {
+        $styleVariables[] = $cssVar . ': ' . htmlspecialchars((string)$$configKey, ENT_QUOTES);
+    }
+}
+
+$backgroundImageUrl = null;
+if (isset($BACKGROUND_IMAGE_URL) && $BACKGROUND_IMAGE_URL !== '') {
+    $backgroundImageUrl = chatbot_asset_url((string)$BACKGROUND_IMAGE_URL, $HOTEL_BASE_PATH ?? null);
+}
+
+if (!empty($styleVariables) || $backgroundImageUrl) {
+    echo "<style>\n";
+    if (!empty($styleVariables)) {
+        echo ":root {\n";
+        foreach ($styleVariables as $line) {
+            echo '    ' . $line . "\n";
+        }
+        echo "}\n";
+    }
+    if ($backgroundImageUrl) {
+        $escaped = htmlspecialchars($backgroundImageUrl, ENT_QUOTES);
+        echo "body { background-image: url('{$escaped}'); }\n";
+    }
+    echo "</style>\n";
+}

--- a/core/privacy.php
+++ b/core/privacy.php
@@ -12,10 +12,7 @@ require_once __DIR__ . '/init.php';
 
 $coreRelative = $coreRelative ?? '..';
 
-$logoSrc = null;
-if (isset($LOGO_PATH) && file_exists($LOGO_PATH)) {
-    $logoSrc = basename($LOGO_PATH);
-}
+$logoSrc = chatbot_asset_url($LOGO_PATH ?? null, $HOTEL_BASE_PATH ?? null);
 
 $chatReturnUrl = $chatReturnUrl ?? 'index.php';
 
@@ -31,6 +28,7 @@ $chatReturnUrl = $chatReturnUrl ?? 'index.php';
     if (isset($hotelCssUrl) && $hotelCssUrl) {
         echo '<link rel="stylesheet" href="' . htmlspecialchars($hotelCssUrl) . '">';
     }
+    include __DIR__ . '/partials/style_overrides.php';
     ?>
 </head>
 <body class="privacy-page">


### PR DESCRIPTION
## Summary
- add prompt text, logo path, background image and key color settings to the admin interface
- load configurable style overrides via CSS custom properties and a reusable partial
- extend the sample configuration and helper utilities to support resolving asset URLs

## Testing
- php -l core/config.sample.php
- php -l core/init.php
- php -l core/admin.php
- php -l core/index.php
- php -l core/privacy.php
- php -l core/partials/style_overrides.php

------
https://chatgpt.com/codex/tasks/task_e_68d17c8b46288324a6d58a5fa6adf68c