### PR TITLE
Align hotel themes with shared chat CSS variables

### DIFF
--- a/aarnhoog/assets/css/hotel.css
+++ b/aarnhoog/assets/css/hotel.css
@@ -1,68 +1,77 @@
 /*
  * AARNHOOG – hotelspezifische Stile
- * Annahme: Logo ist WEISS (transparent) → dunkler Header-Hintergrund.
- * Farbschema: ruhiges Nordsee-Teal als Primärfarbe, warmes Offwhite als Fläche.
+ * Bindet das Corporate-Design in die Chatoberfläche ein, ohne die
+ * gemeinsamen Theme-Variablen zu überschreiben.
  */
 
-:root{
-  --ah-ink: #123C48;           /* dunkles Blaugrün für Texte, Linien */
-  --ah-ink-80: rgba(18,60,72,.85);
-  --ah-ink-20: rgba(18,60,72,.2);
-  --ah-brand: #0F6E8F;         /* Aarnhoog Akzent/Brand (Teal) */
-  --ah-bg: #FFFFFF;            /* Grundfläche */
-  --ah-bubble-user: #0F6E8F;   /* User-Bubble (negativ/weiß) */
-  --ah-bubble-bot: #F1F6F7;    /* sehr hell, leicht bläulich */
-  --ah-header: #0D2C33;        /* sehr dunkler Header für weißes Logo */
-  --ah-focus: #0F6E8F;
+:root {
+  --hotel-background-image: url('../images/background.jpg');
+  --chat-background-color: #ffffff;
+  --chat-box-background-color: #ffffff;
+  --chat-primary-color: #0F6E8F;
+  --chat-primary-text-color: #ffffff;
+  --chat-link-color: var(--chat-primary-color);
+  --chat-user-bubble-color: #0F6E8F;
+  --chat-user-text-color: #ffffff;
+  --chat-bot-bubble-color: #F1F6F7;
+  --chat-bot-text-color: #123C48;
+  --hotel-border-color: color-mix(in srgb, var(--chat-bot-text-color) 20%, transparent);
+  --hotel-muted-text-color: color-mix(in srgb, var(--chat-bot-text-color) 85%, transparent);
+  --hotel-header-background: color-mix(in srgb, var(--chat-primary-color) 35%, #000 65%);
+  --hotel-button-border-color: color-mix(in srgb, var(--chat-primary-color) 70%, #000 30%);
+  --hotel-disabled-button-background: color-mix(in srgb, var(--chat-primary-color) 25%, #fff 75%);
+  --hotel-return-link-background: color-mix(in srgb, var(--chat-primary-color) 80%, #000 20%);
 }
 
-/* Typo: eleganter Sans-Serif-Fallback; wenn ihr Branding-Fonts habt, hier einbinden */
-html, body{
-  font-family: "Avenir Next","Helvetica Neue",Arial,sans-serif;
-  color: var(--ah-ink);
-  background: url('../images/background.jpg') no-repeat center center fixed!important;
-  background-size: cover !important;
+html,
+body {
+  font-family: "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  color: var(--chat-bot-text-color);
+  background-color: var(--chat-background-color);
+  background-image: var(--chat-background-image, var(--hotel-background-image));
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+  background-attachment: fixed;
 }
-
-
 
 /* Chat-Container */
-.chat-box{
-  background: #fff;
+.chat-box {
+  background: var(--chat-box-background-color);
   border-radius: 14px;
-  box-shadow: 0 8px 28px rgba(0,0,0,.10);
-  border: 1px solid var(--ah-ink-20);
-  overflow: hidden; /* damit Header oben bündig ist */
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--hotel-border-color);
+  overflow: hidden;
 }
 
-/* Header mit dunklem Balken für weißes Logo */
-.chat-box header{
-  background: var(--ah-header);
+/* Header mit dunklem Balken für das Logo */
+.chat-box header {
+  background: var(--hotel-header-background);
+  color: var(--chat-primary-text-color);
   padding: 14px 0 12px;
-  border-bottom: 1px solid rgba(255,255,255,.12);
+  border-bottom: 1px solid color-mix(in srgb, var(--chat-primary-text-color) 12%, transparent);
   margin-bottom: 10px;
   text-align: center;
 }
-.chat-box header img{
+
+.chat-box header img {
   max-width: 210px;
   height: auto;
   display: inline-block;
-  filter: none; /* weißes Logo unverändert */
 }
 
-/* Optionaler Claim unter dem Logo (falls gewünscht) */
-.brand-claim{
-  color: rgba(255,255,255,.9);
+.brand-claim {
+  color: color-mix(in srgb, var(--chat-primary-text-color) 90%, transparent);
   font-size: 11px;
-  letter-spacing: .12em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   margin-top: 4px;
 }
 
 /* Chatbereich */
-#chat-log{
-  background: #fff;
-  border: 1px solid var(--ah-ink-20);
+#chat-log {
+  background: var(--chat-box-background-color);
+  border: 1px solid var(--hotel-border-color);
   border-radius: 10px;
   display: flex;
   flex-direction: column;
@@ -71,76 +80,98 @@ html, body{
 }
 
 /* Bubbles – Bot links, User rechts */
-.msg{ display:flex; width:100%; }
-.msg .bubble{
+.msg {
+  display: flex;
+  width: 100%;
+}
+
+.msg .bubble {
   max-width: 78%;
   padding: 10px 14px;
   border-radius: 14px;
   line-height: 1.5;
   font-size: 15px;
-  letter-spacing: .01em;
+  letter-spacing: 0.01em;
 }
 
 /* Bot (links, positiv) */
-.msg.bot{ justify-content:flex-start; }
-.msg.bot .bubble{
-  background: var(--ah-bubble-bot);
-  color: var(--ah-ink);
-  border-top-left-radius: 4px;
-  border: 1px solid var(--ah-ink-20);
+.msg.bot {
+  justify-content: flex-start;
 }
 
-/* User (rechts, negativ/weiß) */
-.msg.user{ justify-content:flex-end; }
-.msg.user .bubble{
-  background: var(--ah-bubble-user);
-  color: #fff;
+.msg.bot .bubble {
+  background: var(--chat-bot-bubble-color);
+  color: var(--chat-bot-text-color);
+  border-top-left-radius: 4px;
+  border: 1px solid var(--hotel-border-color);
+}
+
+/* User (rechts, negativ) */
+.msg.user {
+  justify-content: flex-end;
+}
+
+.msg.user .bubble {
+  background: var(--chat-user-bubble-color);
+  color: var(--chat-user-text-color);
   border-top-right-radius: 4px;
-  border: 1px solid color-mix(in srgb, var(--ah-bubble-user) 70%, #000 30%);
+  border: 1px solid color-mix(in srgb, var(--chat-user-bubble-color) 70%, #000 30%);
   text-align: right;
 }
 
 /* Labels „Max:“ / „Du:“ zurückhaltend */
-.msg .bubble strong{
+.msg .bubble strong {
   font-weight: 600;
-  letter-spacing: .04em;
-  opacity: .95;
-  margin-right: .35em;
+  letter-spacing: 0.04em;
+  opacity: 0.95;
+  margin-right: 0.35em;
 }
 
 /* Eingabe & Buttons */
-.chat-controls input[type="text"]{
-  border: 1px solid var(--ah-ink-20);
+.chat-controls input[type="text"] {
+  border: 1px solid var(--hotel-border-color);
   border-radius: 10px;
   padding: 12px 14px;
   font-size: 15px;
 }
-.chat-controls input[type="text"]:focus{
+
+.chat-controls input[type="text"]:focus {
   outline: 2px solid transparent;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ah-focus) 25%, transparent);
-  border-color: var(--ah-focus);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--chat-primary-color) 25%, transparent);
+  border-color: var(--chat-primary-color);
 }
-.chat-controls .privacy{ color: var(--ah-ink-80); }
-.chat-controls button{
-  background: var(--ah-brand);
-  color: #fff;
+
+.chat-controls .privacy {
+  color: var(--hotel-muted-text-color);
+}
+
+.chat-controls button {
+  background: var(--chat-primary-color);
+  color: var(--chat-primary-text-color);
   border-radius: 10px;
   padding: 10px 14px;
-  letter-spacing: .03em;
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
+  letter-spacing: 0.03em;
+  border: 1px solid var(--hotel-button-border-color);
 }
-.chat-controls button:disabled{
-  background: #9FB8C1;
-  border-color: #9FB8C1;
+
+.chat-controls button:disabled {
+  background: var(--hotel-disabled-button-background);
+  border-color: var(--hotel-disabled-button-background);
 }
 
 /* „Zurück zur Website“-Button */
-.return-link{
-  background: rgba(15,110,143,.9);
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
-  color: #fff;
+.return-link {
+  background: var(--hotel-return-link-background);
+  border: 1px solid var(--hotel-button-border-color);
+  color: var(--chat-primary-text-color);
 }
 
 /* Links im Chat */
-#chat-log a{ color: var(--ah-brand); text-decoration-thickness: 1px; }
-#chat-log ul{ padding-left: 1.2em; }
+#chat-log a {
+  color: var(--chat-link-color);
+  text-decoration-thickness: 1px;
+}
+
+#chat-log ul {
+  padding-left: 1.2em;
+}

--- a/core/partials/style_overrides.php
+++ b/core/partials/style_overrides.php
@@ -24,6 +24,10 @@ foreach ($colorMap as $configKey => $cssVar) {
 $backgroundImageUrl = null;
 if (isset($BACKGROUND_IMAGE_URL) && $BACKGROUND_IMAGE_URL !== '') {
     $backgroundImageUrl = chatbot_asset_url((string)$BACKGROUND_IMAGE_URL, $HOTEL_BASE_PATH ?? null);
+    if ($backgroundImageUrl) {
+        $escapedUrl = htmlspecialchars($backgroundImageUrl, ENT_QUOTES);
+        $styleVariables[] = "--chat-background-image: url('{$escapedUrl}')";
+    }
 }
 
 if (!empty($styleVariables) || $backgroundImageUrl) {

--- a/faehrhaus/assets/css/hotel.css
+++ b/faehrhaus/assets/css/hotel.css
@@ -1,175 +1,203 @@
 /*
  * FÄHRHAUS SYLT – hotelspezifische Stile gemäß CI
- * Farbe: Pantone 432 → #2D393B
- * Typo: Futura (Light/Book/Medium). Falls nicht lizenziert: System-Fallbacks.
  */
 
-/* ====== Typografie ====== */
 @font-face {
-  /* Optional: Wenn ihr eine lizenzierte Futura-Datei hostet, hier einbinden.
-     Andernfalls greifen die Fallbacks. */
   font-family: "FuturaCustom";
   src: url("../fonts/Futura-Book.woff2") format("woff2");
   font-weight: 400;
   font-style: normal;
   font-display: swap;
 }
+
 :root {
-  --fh-ink: #2D393B;            /* Primärschrift-/Linienfarbe */
-  --fh-ink-80: rgba(45,57,59,.8);
-  --fh-ink-20: rgba(45,57,59,.2);
-  --fh-accent: #2D393B;         /* Akzent bleibt tonal */
-  --fh-bg: rgb(45,57,59);             /* grauer Hintergrund */
-  --fh-bubble-user: #2D393B;    /* User-Blase dunkel (negativ, weiße Schrift) */
-  --fh-bubble-bot: #F3F5F5;     /* Sehr helles Grau mit leichter Blaugrün-Note */
-  --fh-focus: #2D393B;
+  --hotel-background-image: url('../images/background.jpg');
+  --chat-background-color: #2D393B;
+  --chat-box-background-color: rgb(45, 57, 59);
+  --chat-primary-color: #2D393B;
+  --chat-primary-text-color: #ffffff;
+  --chat-link-color: var(--chat-primary-color);
+  --chat-user-bubble-color: #2D393B;
+  --chat-user-text-color: #ffffff;
+  --chat-bot-bubble-color: #F3F5F5;
+  --chat-bot-text-color: #2D393B;
+  --hotel-border-color: color-mix(in srgb, var(--chat-bot-text-color) 20%, transparent);
+  --hotel-muted-text-color: color-mix(in srgb, var(--chat-bot-text-color) 80%, transparent);
+  --hotel-return-link-background: color-mix(in srgb, var(--chat-primary-color) 85%, transparent);
+  --hotel-disabled-button-background: color-mix(in srgb, var(--chat-primary-color) 30%, #fff 70%);
 }
 
-html, body {
+html,
+body {
   font-family: "FuturaCustom", "Futura", "Futura PT", "Avenir Next", "Helvetica Neue", Arial, sans-serif;
-  color: var(--fh-ink);
-  background: url('../images/background.jpg') no-repeat center center fixed !important;
-  background-size: cover !important;
+  color: var(--chat-bot-text-color);
+  background-color: var(--chat-background-color);
+  background-image: var(--chat-background-image, var(--hotel-background-image));
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+  background-attachment: fixed;
 }
 
-/* Grundlayout (Core überschreiben) */
+/* Grundlayout */
 .chat-box {
-  background: var(--fh-bg);
+  background: var(--chat-box-background-color);
   border-radius: 14px;
-  box-shadow: 0 8px 28px rgba(0,0,0,.12);
-  border: 1px solid var(--fh-ink-20);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.12);
+  border: 1px solid var(--hotel-border-color);
 }
 
 /* Header mit Logo + optionalem Claim */
 .chat-box header {
   padding: 6px 0 10px;
-  border-bottom: 1px solid var(--fh-ink-20);
+  border-bottom: 1px solid var(--hotel-border-color);
   margin-bottom: 10px;
 }
+
 .chat-box header img {
   max-width: 220px;
   height: auto;
   display: block;
   margin: 0 auto 6px auto;
-  filter: none; /* Logo unverfälscht anzeigen */
 }
+
 .brand-claim {
   font-size: 10px;
-  letter-spacing: .18em;      /* Headlines 100–200 → 0.10–0.20em */
+  letter-spacing: 0.18em;
   text-align: center;
-  color: var(--fh-ink-80);
+  color: var(--hotel-muted-text-color);
   margin-top: 2px;
 }
 
 /* Chatbereich */
 #chat-log {
-  background: #fff;
-  border: 1px solid var(--fh-ink-20);
+  background: var(--chat-primary-text-color);
+  border: 1px solid var(--hotel-border-color);
   border-radius: 10px;
 }
 
-/* Bubbles – links (Bot) / rechts (User) im Messenger-Stil */
-.msg { display: flex; width: 100%; }
+/* Bubbles – links (Bot) / rechts (User) */
+.msg {
+  display: flex;
+  width: 100%;
+}
+
 .msg .bubble {
   max-width: 78%;
   padding: 10px 14px;
   border-radius: 14px;
   line-height: 1.5;
-  font-size: 14.5px;           /* Fließtext ~12pt → ca. 16px; hier minimal kleiner, wirkt eleganter */
-  letter-spacing: .02em;       /* Fließtext Laufweite ~50 → ~0.05em; wir gehen moderat */
+  font-size: 14.5px;
+  letter-spacing: 0.02em;
 }
 
-/* Bot (links, positiv) */
-.msg.bot { justify-content: flex-start; }
+.msg.bot {
+  justify-content: flex-start;
+}
+
 .msg.bot .bubble {
-  background: var(--fh-bubble-bot);
-  color: var(--fh-ink);
+  background: var(--chat-bot-bubble-color);
+  color: var(--chat-bot-text-color);
   border-top-left-radius: 4px;
-  border: 1px solid var(--fh-ink-20);
+  border: 1px solid var(--hotel-border-color);
 }
 
-/* User (rechts, negativ) */
-.msg.user { justify-content: flex-end; }
+.msg.user {
+  justify-content: flex-end;
+}
+
 .msg.user .bubble {
-  background: var(--fh-bubble-user);
-  color: #fff;
+  background: var(--chat-user-bubble-color);
+  color: var(--chat-user-text-color);
   border-top-right-radius: 4px;
-  letter-spacing: .03em;       /* etwas mehr Tracking für Negativschrift */
+  letter-spacing: 0.03em;
   text-align: right;
-  border: 1px solid var(--fh-ink);
+  border: 1px solid var(--chat-primary-color);
 }
 
-/* Labels „Max:“ / „Du:“ zurückhaltend (Book/Medium) */
+/* Labels */
 .msg .bubble strong {
-  letter-spacing: .05em;
-  font-weight: 500;            /* Medium */
+  letter-spacing: 0.05em;
+  font-weight: 500;
   display: inline-block;
-  margin-right: .35em;
-  opacity: .9;
+  margin-right: 0.35em;
+  opacity: 0.9;
 }
 
 /* Eingabe + Buttons */
 .chat-controls input[type="text"] {
-  border: 1px solid var(--fh-ink-20);
+  border: 1px solid var(--hotel-border-color);
   border-radius: 10px;
   padding: 12px 14px;
   font-size: 15px;
-  letter-spacing: .02em;
+  letter-spacing: 0.02em;
 }
+
 .chat-controls input[type="text"]:focus {
   outline: 2px solid transparent;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--fh-focus) 30%, transparent);
-  border-color: var(--fh-focus);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--chat-primary-color) 30%, transparent);
+  border-color: var(--chat-primary-color);
 }
+
 .chat-controls .privacy {
-  color: white;
+  color: var(--chat-primary-text-color);
 }
+
 .chat-controls button {
-  background: #fff;
-  color: var(--fh-ink);
+  background: var(--chat-primary-text-color);
+  color: var(--chat-bot-text-color);
   border-radius: 10px;
   padding: 10px 14px;
-  letter-spacing: .06em;       /* leichter „Button“-Look */
+  letter-spacing: 0.06em;
+  border: 1px solid transparent;
 }
+
 .chat-controls button:disabled {
-  background: #9AA3A5;
+  background: var(--hotel-disabled-button-background);
+  color: var(--chat-primary-text-color);
 }
 
 /* Sekundäre Elemente */
 .return-link {
-  background: rgba(45,57,59, .85);
-  border: 1px solid var(--fh-ink);
+  background: var(--hotel-return-link-background);
+  border: 1px solid var(--chat-primary-color);
+  color: var(--chat-primary-text-color);
 }
 
-/* Kleintypografie im Log (Links, Listen) */
+/* Kleintypografie im Log */
 #chat-log a {
-  color: var(--fh-ink);
+  color: var(--chat-link-color);
   text-decoration-thickness: 1px;
 }
-#chat-log ul { padding-left: 1.2em; }
 
-/* Headline-Typo – falls irgendwo Überschriften auftauchen */
-h1, h2, h3 {
-  text-transform: uppercase; 
-  letter-spacing: .14em;      /* 100–200 → 0.10–0.20em, mittig gewählt */
-  font-weight: 500;           /* Book/Medium */
+#chat-log ul {
+  padding-left: 1.2em;
+}
+
+/* Headline-Typo */
+h1,
+h2,
+h3 {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-weight: 500;
 }
 
 .privacy-box .privacy-content h1 {
   margin: 0 0 16px;
   font-size: 26px;
-  color: #fff;
+  color: var(--chat-primary-text-color);
 }
 
 .privacy-box .privacy-content h2 {
   margin: 24px 0 8px;
   font-size: 18px;
-  color: #c2c2c2ff;
+  color: color-mix(in srgb, var(--chat-primary-text-color) 70%, transparent);
 }
 
 .privacy-box .privacy-content p,
 .privacy-box .privacy-content ul,
 .privacy-box .privacy-content address {
-  color: #e4e4e4ff;
+  color: color-mix(in srgb, var(--chat-primary-text-color) 85%, transparent);
   margin: 0 0 12px;
 }

--- a/roth/assets/css/hotel.css
+++ b/roth/assets/css/hotel.css
@@ -1,62 +1,75 @@
-:root{
-  --ah-ink: #000;           /* dunkles Blaugrün für Texte, Linien */
-  --ah-ink-80: #ae2a23ce;
-  --ah-ink-20: #ae2a234a;
-  --ah-brand: #ae2b23;         /* Hotel Roth Akzent/Brand (Teal) */
-  --ah-bg: #FFFFFF;            /* Grundfläche */
-  --ah-bubble-user: #ae2b23;   /* User-Bubble (negativ/weiß) */
-  --ah-bubble-bot: #F1F6F7;    /* sehr hell, leicht bläulich */
-  --ah-header: #ae2b23;        /* sehr dunkler Header für weißes Logo */
-  --ah-focus: #ae2b23;
+/*
+ * Hotel Roth – individuelle Styles auf Basis der gemeinsamen Chat-Variablen.
+ */
+
+:root {
+  --hotel-background-image: url('../images/background.jpg');
+  --chat-background-color: #ffffff;
+  --chat-box-background-color: #ffffff;
+  --chat-primary-color: #AE2B23;
+  --chat-primary-text-color: #ffffff;
+  --chat-link-color: var(--chat-primary-color);
+  --chat-user-bubble-color: #AE2B23;
+  --chat-user-text-color: #ffffff;
+  --chat-bot-bubble-color: color-mix(in srgb, var(--chat-primary-color) 12%, #ffffff 88%);
+  --chat-bot-text-color: #211714;
+  --hotel-border-color: color-mix(in srgb, var(--chat-bot-text-color) 20%, transparent);
+  --hotel-muted-text-color: color-mix(in srgb, var(--chat-bot-text-color) 70%, transparent);
+  --hotel-header-background: color-mix(in srgb, var(--chat-primary-color) 45%, #000 55%);
+  --hotel-button-border-color: color-mix(in srgb, var(--chat-primary-color) 70%, #000 30%);
+  --hotel-disabled-button-background: color-mix(in srgb, var(--chat-primary-color) 25%, #fff 75%);
+  --hotel-return-link-background: color-mix(in srgb, var(--chat-primary-color) 80%, #000 20%);
 }
 
-/* Typo: eleganter Sans-Serif-Fallback; wenn ihr Branding-Fonts habt, hier einbinden */
-html, body{
-  font-family: "Avenir Next","Helvetica Neue",Arial,sans-serif;
-  color: var(--ah-ink);
-  background: url('../images/background.jpg') no-repeat center center fixed!important;
-  background-size: cover !important;
+html,
+body {
+  font-family: "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  color: var(--chat-bot-text-color);
+  background-color: var(--chat-background-color);
+  background-image: var(--chat-background-image, var(--hotel-background-image));
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+  background-attachment: fixed;
 }
-
-
 
 /* Chat-Container */
-.chat-box{
-  background: #fff;
+.chat-box {
+  background: var(--chat-box-background-color);
   border-radius: 14px;
-  box-shadow: 0 8px 28px rgba(0,0,0,.10);
-  border: 1px solid var(--ah-ink-20);
-  overflow: hidden; /* damit Header oben bündig ist */
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--hotel-border-color);
+  overflow: hidden;
 }
 
-/* Header mit dunklem Balken für weißes Logo */
-.chat-box header{
-  background: var(--ah-header);
+/* Header mit Logo */
+.chat-box header {
+  background: var(--hotel-header-background);
+  color: var(--chat-primary-text-color);
   padding: 14px 0 12px;
-  border-bottom: 1px solid rgba(255,255,255,.12);
+  border-bottom: 1px solid color-mix(in srgb, var(--chat-primary-text-color) 12%, transparent);
   margin-bottom: 10px;
   text-align: center;
 }
-.chat-box header img{
+
+.chat-box header img {
   max-width: 210px;
   height: auto;
   display: inline-block;
-  filter: none; /* weißes Logo unverändert */
 }
 
-/* Optionaler Claim unter dem Logo (falls gewünscht) */
-.brand-claim{
-  color: rgba(255,255,255,.9);
+.brand-claim {
+  color: color-mix(in srgb, var(--chat-primary-text-color) 90%, transparent);
   font-size: 11px;
-  letter-spacing: .12em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   margin-top: 4px;
 }
 
 /* Chatbereich */
-#chat-log{
-  background: #fff;
-  border: 1px solid var(--ah-ink-20);
+#chat-log {
+  background: var(--chat-box-background-color);
+  border: 1px solid var(--hotel-border-color);
   border-radius: 10px;
   display: flex;
   flex-direction: column;
@@ -65,76 +78,93 @@ html, body{
 }
 
 /* Bubbles – Bot links, User rechts */
-.msg{ display:flex; width:100%; }
-.msg .bubble{
+.msg {
+  display: flex;
+  width: 100%;
+}
+
+.msg .bubble {
   max-width: 78%;
   padding: 10px 14px;
   border-radius: 14px;
   line-height: 1.5;
   font-size: 15px;
-  letter-spacing: .01em;
+  letter-spacing: 0.01em;
 }
 
-/* Bot (links, positiv) */
-.msg.bot{ justify-content:flex-start; }
-.msg.bot .bubble{
-  background: var(--ah-bubble-bot);
-  color: var(--ah-ink);
+.msg.bot {
+  justify-content: flex-start;
+}
+
+.msg.bot .bubble {
+  background: var(--chat-bot-bubble-color);
+  color: var(--chat-bot-text-color);
   border-top-left-radius: 4px;
-  border: 1px solid var(--ah-ink-20);
+  border: 1px solid var(--hotel-border-color);
 }
 
-/* User (rechts, negativ/weiß) */
-.msg.user{ justify-content:flex-end; }
-.msg.user .bubble{
-  background: var(--ah-bubble-user);
-  color: #fff;
+.msg.user {
+  justify-content: flex-end;
+}
+
+.msg.user .bubble {
+  background: var(--chat-user-bubble-color);
+  color: var(--chat-user-text-color);
   border-top-right-radius: 4px;
-  border: 1px solid color-mix(in srgb, var(--ah-bubble-user) 70%, #000 30%);
+  border: 1px solid color-mix(in srgb, var(--chat-user-bubble-color) 70%, #000 30%);
   text-align: right;
 }
 
-/* Labels „Max:“ / „Du:“ zurückhaltend */
-.msg .bubble strong{
+.msg .bubble strong {
   font-weight: 600;
-  letter-spacing: .04em;
-  opacity: .95;
-  margin-right: .35em;
+  letter-spacing: 0.04em;
+  opacity: 0.95;
+  margin-right: 0.35em;
 }
 
 /* Eingabe & Buttons */
-.chat-controls input[type="text"]{
-  border: 1px solid var(--ah-ink-20);
+.chat-controls input[type="text"] {
+  border: 1px solid var(--hotel-border-color);
   border-radius: 10px;
   padding: 12px 14px;
   font-size: 15px;
 }
-.chat-controls input[type="text"]:focus{
+
+.chat-controls input[type="text"]:focus {
   outline: 2px solid transparent;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ah-focus) 25%, transparent);
-  border-color: var(--ah-focus);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--chat-primary-color) 25%, transparent);
+  border-color: var(--chat-primary-color);
 }
-.chat-controls .privacy{ color: var(--ah-ink-80); }
-.chat-controls button{
-  background: var(--ah-brand);
-  color: #fff;
+
+.chat-controls .privacy {
+  color: var(--hotel-muted-text-color);
+}
+
+.chat-controls button {
+  background: var(--chat-primary-color);
+  color: var(--chat-primary-text-color);
   border-radius: 10px;
   padding: 10px 14px;
-  letter-spacing: .03em;
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
-}
-.chat-controls button:disabled{
-  background: #9FB8C1;
-  border-color: #9FB8C1;
+  letter-spacing: 0.03em;
+  border: 1px solid var(--hotel-button-border-color);
 }
 
-/* „Zurück zur Website“-Button */
-.return-link{
-  background: rgba(15,110,143,.9);
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
-  color: #fff;
+.chat-controls button:disabled {
+  background: var(--hotel-disabled-button-background);
+  border-color: var(--hotel-disabled-button-background);
 }
 
-/* Links im Chat */
-#chat-log a{ color: var(--ah-brand); text-decoration-thickness: 1px; }
-#chat-log ul{ padding-left: 1.2em; }
+.return-link {
+  background: var(--hotel-return-link-background);
+  border: 1px solid var(--hotel-button-border-color);
+  color: var(--chat-primary-text-color);
+}
+
+#chat-log a {
+  color: var(--chat-link-color);
+  text-decoration-thickness: 1px;
+}
+
+#chat-log ul {
+  padding-left: 1.2em;
+}


### PR DESCRIPTION
## Summary
- refactor each hotel stylesheet to derive colors and backgrounds from the shared chat CSS custom properties instead of hard-coded values
- remove forced background-image overrides and introduce fallbacks that respect the admin-configured image via a new --chat-background-image variable

## Testing
- php -l core/partials/style_overrides.php

------
https://chatgpt.com/codex/tasks/task_e_68d256bd6f28832499ba0944f7eaf32a