### PR TITLE
Refactor shared chat theme and repair logo resolution

### DIFF
--- a/aarnhoog/assets/css/hotel.css
+++ b/aarnhoog/assets/css/hotel.css
@@ -1,146 +1,31 @@
 /*
  * AARNHOOG – hotelspezifische Stile
- * Annahme: Logo ist WEISS (transparent) → dunkler Header-Hintergrund.
- * Farbschema: ruhiges Nordsee-Teal als Primärfarbe, warmes Offwhite als Fläche.
+ * Beschränkt sich auf Variablen, die der Core verwendet.
  */
 
-:root{
-  --ah-ink: #123C48;           /* dunkles Blaugrün für Texte, Linien */
-  --ah-ink-80: rgba(18,60,72,.85);
-  --ah-ink-20: rgba(18,60,72,.2);
-  --ah-brand: #0F6E8F;         /* Aarnhoog Akzent/Brand (Teal) */
-  --ah-bg: #FFFFFF;            /* Grundfläche */
-  --ah-bubble-user: #0F6E8F;   /* User-Bubble (negativ/weiß) */
-  --ah-bubble-bot: #F1F6F7;    /* sehr hell, leicht bläulich */
-  --ah-header: #0D2C33;        /* sehr dunkler Header für weißes Logo */
-  --ah-focus: #0F6E8F;
+:root {
+  --hotel-background-image: url('../images/background.jpg');
+  --chat-font-family: "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  --chat-background-color: #ffffff;
+  --chat-box-background-color: #ffffff;
+  --chat-primary-color: #0F6E8F;
+  --chat-primary-text-color: #ffffff;
+  --chat-link-color: var(--chat-primary-color);
+  --chat-user-bubble-color: #0F6E8F;
+  --chat-user-text-color: #ffffff;
+  --chat-bot-bubble-color: #F1F6F7;
+  --chat-bot-text-color: #123C48;
+  --chat-border-color: color-mix(in srgb, var(--chat-bot-text-color) 20%, transparent);
+  --hotel-border-color: var(--chat-border-color);
+  --chat-muted-text-color: color-mix(in srgb, var(--chat-bot-text-color) 85%, transparent);
+  --hotel-muted-text-color: var(--chat-muted-text-color);
+  --chat-header-background: color-mix(in srgb, var(--chat-primary-color) 35%, #000 65%);
+  --hotel-header-background: var(--chat-header-background);
+  --chat-button-border-color: color-mix(in srgb, var(--chat-primary-color) 70%, #000 30%);
+  --hotel-button-border-color: var(--chat-button-border-color);
+  --chat-disabled-button-background: color-mix(in srgb, var(--chat-primary-color) 25%, #fff 75%);
+  --hotel-disabled-button-background: var(--chat-disabled-button-background);
+  --chat-return-link-background: color-mix(in srgb, var(--chat-primary-color) 80%, #000 20%);
+  --hotel-return-link-background: var(--chat-return-link-background);
+  --chat-input-focus-ring: color-mix(in srgb, var(--chat-primary-color) 25%, transparent);
 }
-
-/* Typo: eleganter Sans-Serif-Fallback; wenn ihr Branding-Fonts habt, hier einbinden */
-html, body{
-  font-family: "Avenir Next","Helvetica Neue",Arial,sans-serif;
-  color: var(--ah-ink);
-  background: url('../images/background.jpg') no-repeat center center fixed!important;
-  background-size: cover !important;
-}
-
-
-
-/* Chat-Container */
-.chat-box{
-  background: #fff;
-  border-radius: 14px;
-  box-shadow: 0 8px 28px rgba(0,0,0,.10);
-  border: 1px solid var(--ah-ink-20);
-  overflow: hidden; /* damit Header oben bündig ist */
-}
-
-/* Header mit dunklem Balken für weißes Logo */
-.chat-box header{
-  background: var(--ah-header);
-  padding: 14px 0 12px;
-  border-bottom: 1px solid rgba(255,255,255,.12);
-  margin-bottom: 10px;
-  text-align: center;
-}
-.chat-box header img{
-  max-width: 210px;
-  height: auto;
-  display: inline-block;
-  filter: none; /* weißes Logo unverändert */
-}
-
-/* Optionaler Claim unter dem Logo (falls gewünscht) */
-.brand-claim{
-  color: rgba(255,255,255,.9);
-  font-size: 11px;
-  letter-spacing: .12em;
-  text-transform: uppercase;
-  margin-top: 4px;
-}
-
-/* Chatbereich */
-#chat-log{
-  background: #fff;
-  border: 1px solid var(--ah-ink-20);
-  border-radius: 10px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px;
-}
-
-/* Bubbles – Bot links, User rechts */
-.msg{ display:flex; width:100%; }
-.msg .bubble{
-  max-width: 78%;
-  padding: 10px 14px;
-  border-radius: 14px;
-  line-height: 1.5;
-  font-size: 15px;
-  letter-spacing: .01em;
-}
-
-/* Bot (links, positiv) */
-.msg.bot{ justify-content:flex-start; }
-.msg.bot .bubble{
-  background: var(--ah-bubble-bot);
-  color: var(--ah-ink);
-  border-top-left-radius: 4px;
-  border: 1px solid var(--ah-ink-20);
-}
-
-/* User (rechts, negativ/weiß) */
-.msg.user{ justify-content:flex-end; }
-.msg.user .bubble{
-  background: var(--ah-bubble-user);
-  color: #fff;
-  border-top-right-radius: 4px;
-  border: 1px solid color-mix(in srgb, var(--ah-bubble-user) 70%, #000 30%);
-  text-align: right;
-}
-
-/* Labels „Max:“ / „Du:“ zurückhaltend */
-.msg .bubble strong{
-  font-weight: 600;
-  letter-spacing: .04em;
-  opacity: .95;
-  margin-right: .35em;
-}
-
-/* Eingabe & Buttons */
-.chat-controls input[type="text"]{
-  border: 1px solid var(--ah-ink-20);
-  border-radius: 10px;
-  padding: 12px 14px;
-  font-size: 15px;
-}
-.chat-controls input[type="text"]:focus{
-  outline: 2px solid transparent;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ah-focus) 25%, transparent);
-  border-color: var(--ah-focus);
-}
-.chat-controls .privacy{ color: var(--ah-ink-80); }
-.chat-controls button{
-  background: var(--ah-brand);
-  color: #fff;
-  border-radius: 10px;
-  padding: 10px 14px;
-  letter-spacing: .03em;
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
-}
-.chat-controls button:disabled{
-  background: #9FB8C1;
-  border-color: #9FB8C1;
-}
-
-/* „Zurück zur Website“-Button */
-.return-link{
-  background: rgba(15,110,143,.9);
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
-  color: #fff;
-}
-
-/* Links im Chat */
-#chat-log a{ color: var(--ah-brand); text-decoration-thickness: 1px; }
-#chat-log ul{ padding-left: 1.2em; }

--- a/core/assets/css/style.css
+++ b/core/assets/css/style.css
@@ -7,124 +7,214 @@
  */
 
 :root {
-  --chat-background-color: #f0f0f0;
-  --chat-box-background-color: #808080;
+  --chat-font-family: "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  --chat-background-color: #f4f7f9;
+  --hotel-background-image: none;
+  --chat-background-image: var(--hotel-background-image);
+  --chat-box-background-color: #ffffff;
   --chat-primary-color: #003366;
   --chat-primary-text-color: #ffffff;
   --chat-link-color: var(--chat-primary-color);
-  --chat-user-bubble-color: #0078d7;
+  --chat-user-bubble-color: #1d4ed8;
   --chat-user-text-color: #ffffff;
-  --chat-bot-bubble-color: #f0f0f0;
-  --chat-bot-text-color: #000000;
+  --chat-bot-bubble-color: #f1f5f9;
+  --chat-bot-text-color: #111827;
+  --chat-border-radius: 14px;
+  --chat-bubble-radius: 14px;
+  --chat-border-color: var(--hotel-border-color, color-mix(in srgb, var(--chat-bot-text-color) 18%, transparent));
+  --chat-muted-text-color: var(--hotel-muted-text-color, color-mix(in srgb, var(--chat-bot-text-color) 70%, transparent));
+  --chat-header-background: var(--hotel-header-background, color-mix(in srgb, var(--chat-primary-color) 35%, #000 65%));
+  --chat-button-background-color: var(--hotel-button-background-color, var(--chat-primary-color));
+  --chat-button-text-color: var(--hotel-button-text-color, var(--chat-primary-text-color));
+  --chat-button-border-color: var(--hotel-button-border-color, color-mix(in srgb, var(--chat-primary-color) 65%, #000 35%));
+  --chat-disabled-button-background: var(--hotel-disabled-button-background, color-mix(in srgb, var(--chat-primary-color) 22%, #fff 78%));
+  --chat-return-link-background: var(--hotel-return-link-background, color-mix(in srgb, var(--chat-primary-color) 80%, #000 20%));
+  --chat-log-background-color: var(--hotel-log-background-color, var(--chat-box-background-color));
+  --chat-input-focus-ring: color-mix(in srgb, var(--chat-primary-color) 30%, transparent);
+  --chat-overlay-padding: clamp(16px, 3vw, 32px);
 }
 
-html, body {
+html,
+body {
   height: 100%;
   margin: 0;
-  font-family: Arial, Helvetica, sans-serif;
 }
 
 body {
-  background: var(--chat-background-color);
+  font-family: var(--chat-font-family);
+  background-color: var(--chat-background-color);
+  background-image: var(--chat-background-image, var(--hotel-background-image, none));
   background-size: cover;
   background-position: center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  color: var(--chat-bot-text-color);
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: var(--chat-link-color);
 }
 
 .chat-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 20px;
+  padding: var(--chat-overlay-padding);
   box-sizing: border-box;
 }
 
 .chat-box {
   display: flex;
   flex-direction: column;
-  width: 100%;
-  max-width: 500px;
-  height: 100%;
-  max-height: 80vh;
+  width: min(520px, 100%);
+  height: min(82vh, 720px);
   background: var(--chat-box-background-color);
-  border-radius: 12px;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.25);
-  padding: 20px;
-  box-sizing: border-box;
+  border-radius: var(--chat-border-radius);
+  border: 1px solid var(--chat-border-color);
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.18);
+  overflow: hidden;
+  backdrop-filter: blur(6px);
 }
 
 .chat-box header {
+  padding: 18px clamp(16px, 4vw, 28px);
+  background: var(--chat-header-background);
+  color: var(--chat-primary-text-color);
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   align-items: center;
-  margin-bottom: 10px;
+  gap: 6px;
+  text-align: center;
+  border-bottom: 1px solid color-mix(in srgb, var(--chat-primary-text-color) 12%, transparent);
 }
 
 .chat-box header img {
-  max-width: 80%;
+  max-width: min(240px, 70%);
+  max-height: 72px;
+  width: auto;
   height: auto;
+  display: block;
+}
+
+.chat-box header h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.brand-claim {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--chat-primary-text-color) 80%, transparent);
 }
 
 #chat-log {
   flex: 1;
+  padding: 16px clamp(12px, 4vw, 20px);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   overflow-y: auto;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  padding: 10px;
-  margin-bottom: 10px;
-  background: #fff;
+  background: var(--chat-log-background-color);
+  border-radius: calc(var(--chat-border-radius) - 4px);
+  border: 1px solid var(--chat-border-color);
+  margin: 0 clamp(16px, 4vw, 24px) 18px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
-.message {
-  margin-bottom: 8px;
-  line-height: 1.4;
+.msg {
+  display: flex;
+  width: 100%;
 }
 
-.message.user {
-  text-align: right;
-  color: var(--chat-primary-color);
-}
-
-.message.bot {
-  text-align: left;
+.msg .bubble {
+  max-width: 78%;
+  padding: 12px 16px;
+  border-radius: var(--chat-bubble-radius);
+  line-height: 1.5;
+  letter-spacing: 0.01em;
+  background: var(--chat-bot-bubble-color);
   color: var(--chat-bot-text-color);
+  border: 1px solid var(--chat-border-color);
+}
+
+.msg.bot {
+  justify-content: flex-start;
+}
+
+.msg.bot .bubble {
+  border-top-left-radius: calc(var(--chat-bubble-radius) / 2);
+}
+
+.msg.user {
+  justify-content: flex-end;
+}
+
+.msg.user .bubble {
+  background: var(--chat-user-bubble-color);
+  color: var(--chat-user-text-color);
+  border-top-right-radius: calc(var(--chat-bubble-radius) / 2);
+  border: 1px solid color-mix(in srgb, var(--chat-user-bubble-color) 65%, #000 35%);
+  text-align: right;
+}
+
+.msg .bubble strong {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  opacity: 0.92;
+  margin-right: 0.35em;
 }
 
 #typing-indicator .bubble {
   font-style: italic;
-  color: var(--chat-bot-text-color);
+  opacity: 0.8;
   background: var(--chat-bot-bubble-color);
-  border-radius: 14px;
-  padding: 8px 12px;
-  opacity: 0.85;
+  color: var(--chat-muted-text-color);
+}
+
+.chat-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0 clamp(16px, 4vw, 24px) clamp(16px, 4vw, 24px);
+  margin-bottom: clamp(12px, 4vw, 18px);
 }
 
 .chat-controls input[type="text"] {
   width: 100%;
-  padding: 8px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--chat-border-color);
+  font-size: 15px;
   box-sizing: border-box;
-  margin-bottom: 6px;
+  background: color-mix(in srgb, var(--chat-box-background-color) 94%, white 6%);
+  color: inherit;
+}
+
+.chat-controls input[type="text"]:focus {
+  outline: 2px solid transparent;
+  box-shadow: 0 0 0 3px var(--chat-input-focus-ring);
+  border-color: var(--chat-primary-color);
 }
 
 .chat-controls .privacy {
   display: flex;
-  align-items: center;
-  margin-bottom: 6px;
+  gap: 8px;
+  align-items: flex-start;
   font-size: 0.9em;
+  color: var(--chat-muted-text-color);
 }
 
 .chat-controls .privacy input[type="checkbox"] {
-  margin-right: 6px;
+  margin-top: 2px;
 }
 
 .chat-controls .privacy a {
-  color: var(--chat-primary-color);
   font-weight: 600;
   text-decoration: underline;
 }
@@ -134,70 +224,117 @@ body {
 }
 
 .chat-controls button {
-  padding: 8px;
-  border: none;
-  border-radius: 4px;
-  background: var(--chat-primary-color);
-  color: var(--chat-primary-text-color);
-  cursor: pointer;
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: 1px solid var(--chat-button-border-color);
+  background: var(--chat-button-background-color);
+  color: var(--chat-button-text-color);
   font-size: 1em;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  transition: filter 0.2s ease;
+}
+
+.chat-controls button:hover:enabled {
+  filter: brightness(1.08);
 }
 
 .chat-controls button:disabled {
-  background: #999;
+  background: var(--chat-disabled-button-background);
+  border-color: var(--chat-disabled-button-background);
   cursor: not-allowed;
+  color: color-mix(in srgb, var(--chat-button-text-color) 80%, transparent);
 }
 
 .return-link {
   position: fixed;
-  bottom: 15px;
-  right: 15px;
-  background: rgba(0, 0, 0, 0.6);
-  color: #fff;
-  padding: 8px 12px;
-  border-radius: 6px;
+  right: clamp(16px, 4vw, 32px);
+  bottom: clamp(16px, 4vw, 32px);
+  background: var(--chat-return-link-background);
+  color: var(--chat-primary-text-color);
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--chat-button-border-color);
   text-decoration: none;
-  font-size: 0.9em;
+  font-size: 0.95em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  backdrop-filter: blur(4px);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.3);
 }
 
 .return-link:hover {
-  background: rgba(0, 0, 0, 0.8);
+  filter: brightness(1.1);
+}
+
+#chat-log a {
+  color: var(--chat-link-color);
+  text-decoration-thickness: 1px;
+}
+
+#chat-log ul {
+  padding-left: 1.2em;
+  margin: 0.5em 0;
+}
+
+@media (max-width: 720px) {
+  .chat-box {
+    height: auto;
+    max-height: none;
+  }
+
+  .chat-controls {
+    padding-inline: clamp(12px, 6vw, 20px);
+  }
+
+  #chat-log {
+    margin-inline: clamp(12px, 6vw, 20px);
+  }
 }
 
 .privacy-box {
-  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  width: min(720px, calc(100% - 32px));
   max-height: 90vh;
-  background: #ffffff;
-  color: #0f172a;
+  padding: clamp(20px, 4vw, 32px);
+  background: var(--chat-box-background-color);
+  color: var(--chat-bot-text-color);
+  border-radius: var(--chat-border-radius);
+  border: 1px solid var(--chat-border-color);
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.2);
+  box-sizing: border-box;
 }
 
 .privacy-box header {
-  margin-bottom: 18px;
+  margin-bottom: 16px;
+  text-align: center;
 }
 
 .privacy-box .privacy-content {
   flex: 1;
   overflow-y: auto;
-  padding-right: 6px;
+  padding-right: 8px;
   line-height: 1.6;
 }
 
 .privacy-box .privacy-content h1 {
   margin: 0 0 16px;
   font-size: 26px;
-  color: #0f172a;
+  color: var(--chat-primary-color);
 }
 
 .privacy-box .privacy-content h2 {
   margin: 24px 0 8px;
   font-size: 18px;
-  color: #111827;
+  color: var(--chat-bot-text-color);
 }
 
 .privacy-box .privacy-content p,
 .privacy-box .privacy-content ul,
 .privacy-box .privacy-content address {
-  color: #334155;
+  color: var(--chat-muted-text-color);
   margin: 0 0 12px;
 }
 
@@ -228,22 +365,24 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 8px;
   background: var(--chat-primary-color);
   color: var(--chat-primary-text-color);
   padding: 10px 18px;
-  border-radius: 6px;
+  border-radius: 999px;
   text-decoration: none;
   font-weight: 600;
-  transition: background 0.2s ease;
+  border: 1px solid var(--chat-button-border-color);
+  transition: filter 0.2s ease;
 }
 
 .privacy-footer .privacy-back:hover {
-  filter: brightness(0.9);
+  filter: brightness(1.08);
 }
 
 @media (max-width: 600px) {
   .privacy-box {
-    max-width: 100%;
+    width: calc(100% - 24px);
     max-height: 94vh;
     padding: 18px;
   }
@@ -255,48 +394,6 @@ body {
   .privacy-box .privacy-content h2 {
     font-size: 17px;
   }
-}
-
-/* Chatblasen-Grundlayout */
-#chat-log {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px;
-}
-
-/* Gemeinsame Basis */
-.msg {
-  display: flex;
-  width: 100%;
-}
-
-.msg .bubble {
-  max-width: 70%;
-  padding: 8px 12px;
-  border-radius: 12px;
-  line-height: 1.4;
-}
-
-/* Bot (links) */
-.msg.bot {
-  justify-content: flex-start;
-}
-.msg.bot .bubble {
-  background: var(--chat-bot-bubble-color);
-  color: var(--chat-bot-text-color);
-  border-top-left-radius: 0;
-}
-
-/* User (rechts) */
-.msg.user {
-  justify-content: flex-end;
-}
-.msg.user .bubble {
-  background: var(--chat-user-bubble-color);
-  color: var(--chat-user-text-color);
-  border-top-right-radius: 0;
-  text-align: right;
 }
 
 

--- a/core/init.php
+++ b/core/init.php
@@ -105,7 +105,7 @@ if (!function_exists('chatbot_asset_url')) {
             return $value;
         }
 
-        if ($value[0] === '/') {
+        if ($value[0] === '/' && !file_exists($value)) {
             return $value;
         }
 

--- a/core/partials/style_overrides.php
+++ b/core/partials/style_overrides.php
@@ -24,6 +24,10 @@ foreach ($colorMap as $configKey => $cssVar) {
 $backgroundImageUrl = null;
 if (isset($BACKGROUND_IMAGE_URL) && $BACKGROUND_IMAGE_URL !== '') {
     $backgroundImageUrl = chatbot_asset_url((string)$BACKGROUND_IMAGE_URL, $HOTEL_BASE_PATH ?? null);
+    if ($backgroundImageUrl) {
+        $escapedUrl = htmlspecialchars($backgroundImageUrl, ENT_QUOTES);
+        $styleVariables[] = "--chat-background-image: url('{$escapedUrl}')";
+    }
 }
 
 if (!empty($styleVariables) || $backgroundImageUrl) {
@@ -31,13 +35,9 @@ if (!empty($styleVariables) || $backgroundImageUrl) {
     if (!empty($styleVariables)) {
         echo ":root {\n";
         foreach ($styleVariables as $line) {
-            echo '    ' . $line . "\n";
+            echo '    ' . $line . ";\n";
         }
         echo "}\n";
-    }
-    if ($backgroundImageUrl) {
-        $escaped = htmlspecialchars($backgroundImageUrl, ENT_QUOTES);
-        echo "body { background-image: url('{$escaped}'); }\n";
     }
     echo "</style>\n";
 }

--- a/faehrhaus/assets/css/hotel.css
+++ b/faehrhaus/assets/css/hotel.css
@@ -1,175 +1,42 @@
 /*
- * FÄHRHAUS SYLT – hotelspezifische Stile gemäß CI
- * Farbe: Pantone 432 → #2D393B
- * Typo: Futura (Light/Book/Medium). Falls nicht lizenziert: System-Fallbacks.
+ * FÄHRHAUS SYLT – hotelspezifische Variablen.
  */
 
-/* ====== Typografie ====== */
 @font-face {
-  /* Optional: Wenn ihr eine lizenzierte Futura-Datei hostet, hier einbinden.
-     Andernfalls greifen die Fallbacks. */
   font-family: "FuturaCustom";
   src: url("../fonts/Futura-Book.woff2") format("woff2");
   font-weight: 400;
   font-style: normal;
   font-display: swap;
 }
+
 :root {
-  --fh-ink: #2D393B;            /* Primärschrift-/Linienfarbe */
-  --fh-ink-80: rgba(45,57,59,.8);
-  --fh-ink-20: rgba(45,57,59,.2);
-  --fh-accent: #2D393B;         /* Akzent bleibt tonal */
-  --fh-bg: rgb(45,57,59);             /* grauer Hintergrund */
-  --fh-bubble-user: #2D393B;    /* User-Blase dunkel (negativ, weiße Schrift) */
-  --fh-bubble-bot: #F3F5F5;     /* Sehr helles Grau mit leichter Blaugrün-Note */
-  --fh-focus: #2D393B;
-}
-
-html, body {
-  font-family: "FuturaCustom", "Futura", "Futura PT", "Avenir Next", "Helvetica Neue", Arial, sans-serif;
-  color: var(--fh-ink);
-  background: url('../images/background.jpg') no-repeat center center fixed !important;
-  background-size: cover !important;
-}
-
-/* Grundlayout (Core überschreiben) */
-.chat-box {
-  background: var(--fh-bg);
-  border-radius: 14px;
-  box-shadow: 0 8px 28px rgba(0,0,0,.12);
-  border: 1px solid var(--fh-ink-20);
-}
-
-/* Header mit Logo + optionalem Claim */
-.chat-box header {
-  padding: 6px 0 10px;
-  border-bottom: 1px solid var(--fh-ink-20);
-  margin-bottom: 10px;
-}
-.chat-box header img {
-  max-width: 220px;
-  height: auto;
-  display: block;
-  margin: 0 auto 6px auto;
-  filter: none; /* Logo unverfälscht anzeigen */
-}
-.brand-claim {
-  font-size: 10px;
-  letter-spacing: .18em;      /* Headlines 100–200 → 0.10–0.20em */
-  text-align: center;
-  color: var(--fh-ink-80);
-  margin-top: 2px;
-}
-
-/* Chatbereich */
-#chat-log {
-  background: #fff;
-  border: 1px solid var(--fh-ink-20);
-  border-radius: 10px;
-}
-
-/* Bubbles – links (Bot) / rechts (User) im Messenger-Stil */
-.msg { display: flex; width: 100%; }
-.msg .bubble {
-  max-width: 78%;
-  padding: 10px 14px;
-  border-radius: 14px;
-  line-height: 1.5;
-  font-size: 14.5px;           /* Fließtext ~12pt → ca. 16px; hier minimal kleiner, wirkt eleganter */
-  letter-spacing: .02em;       /* Fließtext Laufweite ~50 → ~0.05em; wir gehen moderat */
-}
-
-/* Bot (links, positiv) */
-.msg.bot { justify-content: flex-start; }
-.msg.bot .bubble {
-  background: var(--fh-bubble-bot);
-  color: var(--fh-ink);
-  border-top-left-radius: 4px;
-  border: 1px solid var(--fh-ink-20);
-}
-
-/* User (rechts, negativ) */
-.msg.user { justify-content: flex-end; }
-.msg.user .bubble {
-  background: var(--fh-bubble-user);
-  color: #fff;
-  border-top-right-radius: 4px;
-  letter-spacing: .03em;       /* etwas mehr Tracking für Negativschrift */
-  text-align: right;
-  border: 1px solid var(--fh-ink);
-}
-
-/* Labels „Max:“ / „Du:“ zurückhaltend (Book/Medium) */
-.msg .bubble strong {
-  letter-spacing: .05em;
-  font-weight: 500;            /* Medium */
-  display: inline-block;
-  margin-right: .35em;
-  opacity: .9;
-}
-
-/* Eingabe + Buttons */
-.chat-controls input[type="text"] {
-  border: 1px solid var(--fh-ink-20);
-  border-radius: 10px;
-  padding: 12px 14px;
-  font-size: 15px;
-  letter-spacing: .02em;
-}
-.chat-controls input[type="text"]:focus {
-  outline: 2px solid transparent;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--fh-focus) 30%, transparent);
-  border-color: var(--fh-focus);
-}
-.chat-controls .privacy {
-  color: white;
-}
-.chat-controls button {
-  background: #fff;
-  color: var(--fh-ink);
-  border-radius: 10px;
-  padding: 10px 14px;
-  letter-spacing: .06em;       /* leichter „Button“-Look */
-}
-.chat-controls button:disabled {
-  background: #9AA3A5;
-}
-
-/* Sekundäre Elemente */
-.return-link {
-  background: rgba(45,57,59, .85);
-  border: 1px solid var(--fh-ink);
-}
-
-/* Kleintypografie im Log (Links, Listen) */
-#chat-log a {
-  color: var(--fh-ink);
-  text-decoration-thickness: 1px;
-}
-#chat-log ul { padding-left: 1.2em; }
-
-/* Headline-Typo – falls irgendwo Überschriften auftauchen */
-h1, h2, h3 {
-  text-transform: uppercase; 
-  letter-spacing: .14em;      /* 100–200 → 0.10–0.20em, mittig gewählt */
-  font-weight: 500;           /* Book/Medium */
-}
-
-.privacy-box .privacy-content h1 {
-  margin: 0 0 16px;
-  font-size: 26px;
-  color: #fff;
-}
-
-.privacy-box .privacy-content h2 {
-  margin: 24px 0 8px;
-  font-size: 18px;
-  color: #c2c2c2ff;
-}
-
-.privacy-box .privacy-content p,
-.privacy-box .privacy-content ul,
-.privacy-box .privacy-content address {
-  color: #e4e4e4ff;
-  margin: 0 0 12px;
+  --hotel-background-image: url('../images/background.jpg');
+  --chat-font-family: "FuturaCustom", "Futura", "Futura PT", "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  --chat-background-color: #2D393B;
+  --chat-box-background-color: rgb(45, 57, 59);
+  --chat-log-background-color: var(--chat-primary-text-color);
+  --hotel-log-background-color: var(--chat-log-background-color);
+  --chat-primary-color: #2D393B;
+  --chat-primary-text-color: #ffffff;
+  --chat-link-color: var(--chat-primary-color);
+  --chat-user-bubble-color: #2D393B;
+  --chat-user-text-color: #ffffff;
+  --chat-bot-bubble-color: #F3F5F5;
+  --chat-bot-text-color: #2D393B;
+  --chat-border-color: color-mix(in srgb, var(--chat-bot-text-color) 20%, transparent);
+  --hotel-border-color: var(--chat-border-color);
+  --chat-muted-text-color: color-mix(in srgb, var(--chat-bot-text-color) 80%, transparent);
+  --hotel-muted-text-color: var(--chat-muted-text-color);
+  --chat-button-background-color: var(--chat-primary-text-color);
+  --hotel-button-background-color: var(--chat-button-background-color);
+  --chat-button-text-color: var(--chat-bot-text-color);
+  --hotel-button-text-color: var(--chat-button-text-color);
+  --chat-button-border-color: transparent;
+  --hotel-button-border-color: var(--chat-button-border-color);
+  --chat-disabled-button-background: color-mix(in srgb, var(--chat-primary-color) 30%, #fff 70%);
+  --hotel-disabled-button-background: var(--chat-disabled-button-background);
+  --chat-return-link-background: color-mix(in srgb, var(--chat-primary-color) 85%, transparent);
+  --hotel-return-link-background: var(--chat-return-link-background);
+  --chat-input-focus-ring: color-mix(in srgb, var(--chat-primary-color) 30%, transparent);
 }

--- a/roth/assets/css/hotel.css
+++ b/roth/assets/css/hotel.css
@@ -1,140 +1,32 @@
-:root{
-  --ah-ink: #000;           /* dunkles Blaugrün für Texte, Linien */
-  --ah-ink-80: #ae2a23ce;
-  --ah-ink-20: #ae2a234a;
-  --ah-brand: #ae2b23;         /* Hotel Roth Akzent/Brand (Teal) */
-  --ah-bg: #FFFFFF;            /* Grundfläche */
-  --ah-bubble-user: #ae2b23;   /* User-Bubble (negativ/weiß) */
-  --ah-bubble-bot: #F1F6F7;    /* sehr hell, leicht bläulich */
-  --ah-header: #ae2b23;        /* sehr dunkler Header für weißes Logo */
-  --ah-focus: #ae2b23;
-}
+/*
+ * Hotel Roth – Variablen für das gemeinsame Chat-Theme.
+ */
 
-/* Typo: eleganter Sans-Serif-Fallback; wenn ihr Branding-Fonts habt, hier einbinden */
-html, body{
-  font-family: "Avenir Next","Helvetica Neue",Arial,sans-serif;
-  color: var(--ah-ink);
-  background: url('../images/background.jpg') no-repeat center center fixed!important;
-  background-size: cover !important;
+:root {
+  --hotel-background-image: url('../images/background.jpg');
+  --chat-font-family: "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  --chat-background-color: #ffffff;
+  --chat-box-background-color: #ffffff;
+  --chat-primary-color: #AE2B23;
+  --chat-primary-text-color: #ffffff;
+  --chat-link-color: var(--chat-primary-color);
+  --chat-user-bubble-color: #AE2B23;
+  --chat-user-text-color: #ffffff;
+  --chat-bot-bubble-color: color-mix(in srgb, var(--chat-primary-color) 12%, #ffffff 88%);
+  --chat-bot-text-color: #211714;
+  --chat-border-color: color-mix(in srgb, var(--chat-bot-text-color) 20%, transparent);
+  --hotel-border-color: var(--chat-border-color);
+  --chat-muted-text-color: color-mix(in srgb, var(--chat-bot-text-color) 70%, transparent);
+  --hotel-muted-text-color: var(--chat-muted-text-color);
+  --chat-header-background: color-mix(in srgb, var(--chat-primary-color) 45%, #000 55%);
+  --hotel-header-background: var(--chat-header-background);
+  --chat-button-border-color: color-mix(in srgb, var(--chat-primary-color) 70%, #000 30%);
+  --hotel-button-border-color: var(--chat-button-border-color);
+  --chat-button-background-color: var(--chat-primary-color);
+  --hotel-button-background-color: var(--chat-button-background-color);
+  --chat-disabled-button-background: color-mix(in srgb, var(--chat-primary-color) 25%, #fff 75%);
+  --hotel-disabled-button-background: var(--chat-disabled-button-background);
+  --chat-return-link-background: color-mix(in srgb, var(--chat-primary-color) 80%, #000 20%);
+  --hotel-return-link-background: var(--chat-return-link-background);
+  --chat-input-focus-ring: color-mix(in srgb, var(--chat-primary-color) 25%, transparent);
 }
-
-
-
-/* Chat-Container */
-.chat-box{
-  background: #fff;
-  border-radius: 14px;
-  box-shadow: 0 8px 28px rgba(0,0,0,.10);
-  border: 1px solid var(--ah-ink-20);
-  overflow: hidden; /* damit Header oben bündig ist */
-}
-
-/* Header mit dunklem Balken für weißes Logo */
-.chat-box header{
-  background: var(--ah-header);
-  padding: 14px 0 12px;
-  border-bottom: 1px solid rgba(255,255,255,.12);
-  margin-bottom: 10px;
-  text-align: center;
-}
-.chat-box header img{
-  max-width: 210px;
-  height: auto;
-  display: inline-block;
-  filter: none; /* weißes Logo unverändert */
-}
-
-/* Optionaler Claim unter dem Logo (falls gewünscht) */
-.brand-claim{
-  color: rgba(255,255,255,.9);
-  font-size: 11px;
-  letter-spacing: .12em;
-  text-transform: uppercase;
-  margin-top: 4px;
-}
-
-/* Chatbereich */
-#chat-log{
-  background: #fff;
-  border: 1px solid var(--ah-ink-20);
-  border-radius: 10px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px;
-}
-
-/* Bubbles – Bot links, User rechts */
-.msg{ display:flex; width:100%; }
-.msg .bubble{
-  max-width: 78%;
-  padding: 10px 14px;
-  border-radius: 14px;
-  line-height: 1.5;
-  font-size: 15px;
-  letter-spacing: .01em;
-}
-
-/* Bot (links, positiv) */
-.msg.bot{ justify-content:flex-start; }
-.msg.bot .bubble{
-  background: var(--ah-bubble-bot);
-  color: var(--ah-ink);
-  border-top-left-radius: 4px;
-  border: 1px solid var(--ah-ink-20);
-}
-
-/* User (rechts, negativ/weiß) */
-.msg.user{ justify-content:flex-end; }
-.msg.user .bubble{
-  background: var(--ah-bubble-user);
-  color: #fff;
-  border-top-right-radius: 4px;
-  border: 1px solid color-mix(in srgb, var(--ah-bubble-user) 70%, #000 30%);
-  text-align: right;
-}
-
-/* Labels „Max:“ / „Du:“ zurückhaltend */
-.msg .bubble strong{
-  font-weight: 600;
-  letter-spacing: .04em;
-  opacity: .95;
-  margin-right: .35em;
-}
-
-/* Eingabe & Buttons */
-.chat-controls input[type="text"]{
-  border: 1px solid var(--ah-ink-20);
-  border-radius: 10px;
-  padding: 12px 14px;
-  font-size: 15px;
-}
-.chat-controls input[type="text"]:focus{
-  outline: 2px solid transparent;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ah-focus) 25%, transparent);
-  border-color: var(--ah-focus);
-}
-.chat-controls .privacy{ color: var(--ah-ink-80); }
-.chat-controls button{
-  background: var(--ah-brand);
-  color: #fff;
-  border-radius: 10px;
-  padding: 10px 14px;
-  letter-spacing: .03em;
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
-}
-.chat-controls button:disabled{
-  background: #9FB8C1;
-  border-color: #9FB8C1;
-}
-
-/* „Zurück zur Website“-Button */
-.return-link{
-  background: rgba(15,110,143,.9);
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
-  color: #fff;
-}
-
-/* Links im Chat */
-#chat-log a{ color: var(--ah-brand); text-decoration-thickness: 1px; }
-#chat-log ul{ padding-left: 1.2em; }


### PR DESCRIPTION
## Summary
- consolidate the chatbot layout, bubble, control and privacy styling inside `core/assets/css/style.css` with configurable CSS variables and updated defaults
- expose hotel-only CSS files as variable declarations (plus the Fährhaus font) while supporting custom button and chat log colours
- append semicolons to admin overrides and teach `chatbot_asset_url()` to turn absolute file paths into relative URLs so configured logos render correctly

## Testing
- php -l core/partials/style_overrides.php
- php -l core/init.php

------
https://chatgpt.com/codex/tasks/task_e_68d256bd6f28832499ba0944f7eaf32a