### PR TITLE
Refactor hotel styling to use core variables

### DIFF
--- a/aarnhoog/assets/css/hotel.css
+++ b/aarnhoog/assets/css/hotel.css
@@ -4,7 +4,7 @@
  * Farbschema: ruhiges Nordsee-Teal als Primärfarbe, warmes Offwhite als Fläche.
  */
 
-:root{
+:root {
   --ah-ink: #123C48;           /* dunkles Blaugrün für Texte, Linien */
   --ah-ink-80: rgba(18,60,72,.85);
   --ah-ink-20: rgba(18,60,72,.2);
@@ -14,133 +14,87 @@
   --ah-bubble-bot: #F1F6F7;    /* sehr hell, leicht bläulich */
   --ah-header: #0D2C33;        /* sehr dunkler Header für weißes Logo */
   --ah-focus: #0F6E8F;
-}
 
-/* Typo: eleganter Sans-Serif-Fallback; wenn ihr Branding-Fonts habt, hier einbinden */
-html, body{
-  font-family: "Avenir Next","Helvetica Neue",Arial,sans-serif;
-  color: var(--ah-ink);
-  background: url('../images/background.jpg') no-repeat center center fixed!important;
-  background-size: cover !important;
-}
+  --chat-font-family: "Avenir Next","Helvetica Neue",Arial,sans-serif;
+  --chat-text-color: var(--ah-ink);
+  --chat-body-background: url('../images/background.jpg') no-repeat center center fixed;
+  --chat-body-background-size: cover;
+  --chat-body-background-position: center;
+  --chat-body-background-repeat: no-repeat;
+  --chat-body-background-attachment: fixed;
 
+  --chat-box-background: #fff;
+  --chat-box-border-radius: 14px;
+  --chat-box-border: 1px solid var(--ah-ink-20);
+  --chat-box-box-shadow: 0 8px 28px rgba(0,0,0,.10);
+  --chat-box-overflow: hidden;
 
+  --chat-header-background: var(--ah-header);
+  --chat-header-padding: 14px 0 12px;
+  --chat-header-border-bottom: 1px solid rgba(255,255,255,.12);
+  --chat-header-text-align: center;
+  --chat-header-logo-max-width: 210px;
+  --chat-header-logo-display: inline-block;
+  --chat-header-logo-margin: 0;
 
-/* Chat-Container */
-.chat-box{
-  background: #fff;
-  border-radius: 14px;
-  box-shadow: 0 8px 28px rgba(0,0,0,.10);
-  border: 1px solid var(--ah-ink-20);
-  overflow: hidden; /* damit Header oben bündig ist */
-}
+  --brand-claim-color: rgba(255,255,255,.9);
+  --brand-claim-font-size: 11px;
+  --brand-claim-letter-spacing: .12em;
+  --brand-claim-text-transform: uppercase;
+  --brand-claim-margin-top: 4px;
 
-/* Header mit dunklem Balken für weißes Logo */
-.chat-box header{
-  background: var(--ah-header);
-  padding: 14px 0 12px;
-  border-bottom: 1px solid rgba(255,255,255,.12);
-  margin-bottom: 10px;
-  text-align: center;
-}
-.chat-box header img{
-  max-width: 210px;
-  height: auto;
-  display: inline-block;
-  filter: none; /* weißes Logo unverändert */
-}
+  --chat-log-border: 1px solid var(--ah-ink-20);
+  --chat-log-border-radius: 10px;
+  --chat-log-gap: 8px;
+  --chat-log-padding: 10px;
 
-/* Optionaler Claim unter dem Logo (falls gewünscht) */
-.brand-claim{
-  color: rgba(255,255,255,.9);
-  font-size: 11px;
-  letter-spacing: .12em;
-  text-transform: uppercase;
-  margin-top: 4px;
-}
+  --chat-msg-bubble-max-width: 78%;
+  --chat-msg-bubble-padding: 10px 14px;
+  --chat-msg-bubble-border-radius: 14px;
+  --chat-msg-bubble-line-height: 1.5;
+  --chat-msg-bubble-font-size: 15px;
+  --chat-msg-bubble-letter-spacing: .01em;
 
-/* Chatbereich */
-#chat-log{
-  background: #fff;
-  border: 1px solid var(--ah-ink-20);
-  border-radius: 10px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px;
-}
+  --chat-msg-bot-background: var(--ah-bubble-bot);
+  --chat-msg-bot-color: var(--ah-ink);
+  --chat-msg-bot-border-top-left-radius: 4px;
+  --chat-msg-bot-border: 1px solid var(--ah-ink-20);
 
-/* Bubbles – Bot links, User rechts */
-.msg{ display:flex; width:100%; }
-.msg .bubble{
-  max-width: 78%;
-  padding: 10px 14px;
-  border-radius: 14px;
-  line-height: 1.5;
-  font-size: 15px;
-  letter-spacing: .01em;
-}
+  --chat-msg-user-background: var(--ah-bubble-user);
+  --chat-msg-user-color: #fff;
+  --chat-msg-user-border-top-right-radius: 4px;
+  --chat-msg-user-border: 1px solid color-mix(in srgb, var(--ah-bubble-user) 70%, #000 30%);
+  --chat-msg-user-text-align: right;
 
-/* Bot (links, positiv) */
-.msg.bot{ justify-content:flex-start; }
-.msg.bot .bubble{
-  background: var(--ah-bubble-bot);
-  color: var(--ah-ink);
-  border-top-left-radius: 4px;
-  border: 1px solid var(--ah-ink-20);
-}
+  --chat-msg-strong-font-weight: 600;
+  --chat-msg-strong-letter-spacing: .04em;
+  --chat-msg-strong-opacity: .95;
+  --chat-msg-strong-margin-right: .35em;
 
-/* User (rechts, negativ/weiß) */
-.msg.user{ justify-content:flex-end; }
-.msg.user .bubble{
-  background: var(--ah-bubble-user);
-  color: #fff;
-  border-top-right-radius: 4px;
-  border: 1px solid color-mix(in srgb, var(--ah-bubble-user) 70%, #000 30%);
-  text-align: right;
-}
+  --chat-input-border: 1px solid var(--ah-ink-20);
+  --chat-input-border-radius: 10px;
+  --chat-input-padding: 12px 14px;
+  --chat-input-font-size: 15px;
+  --chat-input-focus-outline: 2px solid transparent;
+  --chat-input-focus-box-shadow: 0 0 0 3px color-mix(in srgb, var(--ah-focus) 25%, transparent);
+  --chat-input-focus-border-color: var(--ah-focus);
 
-/* Labels „Max:“ / „Du:“ zurückhaltend */
-.msg .bubble strong{
-  font-weight: 600;
-  letter-spacing: .04em;
-  opacity: .95;
-  margin-right: .35em;
-}
+  --chat-privacy-color: var(--ah-ink-80);
 
-/* Eingabe & Buttons */
-.chat-controls input[type="text"]{
-  border: 1px solid var(--ah-ink-20);
-  border-radius: 10px;
-  padding: 12px 14px;
-  font-size: 15px;
-}
-.chat-controls input[type="text"]:focus{
-  outline: 2px solid transparent;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ah-focus) 25%, transparent);
-  border-color: var(--ah-focus);
-}
-.chat-controls .privacy{ color: var(--ah-ink-80); }
-.chat-controls button{
-  background: var(--ah-brand);
-  color: #fff;
-  border-radius: 10px;
-  padding: 10px 14px;
-  letter-spacing: .03em;
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
-}
-.chat-controls button:disabled{
-  background: #9FB8C1;
-  border-color: #9FB8C1;
-}
+  --chat-button-background: var(--ah-brand);
+  --chat-button-color: #fff;
+  --chat-button-border-radius: 10px;
+  --chat-button-padding: 10px 14px;
+  --chat-button-letter-spacing: .03em;
+  --chat-button-border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
+  --chat-button-disabled-background: #9FB8C1;
+  --chat-button-disabled-border: 1px solid #9FB8C1;
 
-/* „Zurück zur Website“-Button */
-.return-link{
-  background: rgba(15,110,143,.9);
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
-  color: #fff;
-}
+  --return-link-background: rgba(15,110,143,.9);
+  --return-link-border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
+  --return-link-color: #fff;
 
-/* Links im Chat */
-#chat-log a{ color: var(--ah-brand); text-decoration-thickness: 1px; }
-#chat-log ul{ padding-left: 1.2em; }
+  --chat-log-link-color: var(--ah-brand);
+  --chat-log-link-decoration-thickness: 1px;
+  --chat-log-list-padding-left: 1.2em;
+}

--- a/core/assets/css/style.css
+++ b/core/assets/css/style.css
@@ -16,18 +16,115 @@
   --chat-user-text-color: #ffffff;
   --chat-bot-bubble-color: #f0f0f0;
   --chat-bot-text-color: #000000;
+
+  --chat-font-family: Arial, Helvetica, sans-serif;
+  --chat-text-color: inherit;
+  --chat-body-background: var(--chat-background-color);
+  --chat-body-background-size: cover;
+  --chat-body-background-position: center;
+  --chat-body-background-repeat: repeat;
+  --chat-body-background-attachment: scroll;
+
+  --chat-box-background: var(--chat-box-background-color);
+  --chat-box-border-radius: 12px;
+  --chat-box-border: none;
+  --chat-box-box-shadow: 0 4px 15px rgba(0, 0, 0, 0.25);
+  --chat-box-padding: 20px;
+  --chat-box-overflow: visible;
+
+  --chat-header-background: transparent;
+  --chat-header-padding: 0;
+  --chat-header-border-bottom: none;
+  --chat-header-margin-bottom: 10px;
+  --chat-header-text-align: inherit;
+  --chat-header-flex-direction: row;
+  --chat-header-logo-max-width: 80%;
+  --chat-header-logo-display: block;
+  --chat-header-logo-margin: 0 auto;
+  --chat-header-logo-filter: none;
+
+  --brand-claim-color: inherit;
+  --brand-claim-font-size: 0.85rem;
+  --brand-claim-letter-spacing: normal;
+  --brand-claim-text-transform: none;
+  --brand-claim-margin-top: 0;
+  --brand-claim-text-align: center;
+
+  --chat-log-display: flex;
+  --chat-log-flex-direction: column;
+  --chat-log-gap: 8px;
+  --chat-log-border: 1px solid #ddd;
+  --chat-log-border-radius: 4px;
+  --chat-log-padding: 10px;
+  --chat-log-margin-bottom: 10px;
+  --chat-log-background: #fff;
+
+  --chat-msg-bubble-max-width: 70%;
+  --chat-msg-bubble-padding: 8px 12px;
+  --chat-msg-bubble-border-radius: 12px;
+  --chat-msg-bubble-line-height: 1.4;
+  --chat-msg-bubble-font-size: inherit;
+  --chat-msg-bubble-letter-spacing: normal;
+
+  --chat-msg-bot-background: var(--chat-bot-bubble-color);
+  --chat-msg-bot-color: var(--chat-bot-text-color);
+  --chat-msg-bot-border: none;
+  --chat-msg-bot-border-top-left-radius: 0;
+
+  --chat-msg-user-background: var(--chat-user-bubble-color);
+  --chat-msg-user-color: var(--chat-user-text-color);
+  --chat-msg-user-border: none;
+  --chat-msg-user-border-top-right-radius: 0;
+  --chat-msg-user-text-align: right;
+  --chat-msg-user-letter-spacing: normal;
+
+  --chat-msg-strong-font-weight: 600;
+  --chat-msg-strong-letter-spacing: normal;
+  --chat-msg-strong-opacity: 1;
+  --chat-msg-strong-margin-right: 0;
+
+  --chat-input-border: 1px solid #ccc;
+  --chat-input-border-radius: 4px;
+  --chat-input-padding: 8px;
+  --chat-input-font-size: 1em;
+  --chat-input-letter-spacing: normal;
+  --chat-input-focus-outline: auto;
+  --chat-input-focus-box-shadow: none;
+  --chat-input-focus-border-color: var(--chat-primary-color);
+
+  --chat-privacy-color: inherit;
+
+  --chat-button-background: var(--chat-primary-color);
+  --chat-button-color: var(--chat-primary-text-color);
+  --chat-button-border-radius: 4px;
+  --chat-button-padding: 8px;
+  --chat-button-letter-spacing: normal;
+  --chat-button-border: none;
+  --chat-button-disabled-background: #999;
+  --chat-button-disabled-border: none;
+
+  --return-link-background: rgba(0, 0, 0, 0.6);
+  --return-link-color: #fff;
+  --return-link-border: none;
+
+  --chat-log-link-color: var(--chat-link-color);
+  --chat-log-link-decoration-thickness: auto;
+  --chat-log-list-padding-left: 20px;
 }
 
 html, body {
   height: 100%;
   margin: 0;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--chat-font-family, Arial, Helvetica, sans-serif);
+  color: var(--chat-text-color, inherit);
 }
 
 body {
-  background: var(--chat-background-color);
-  background-size: cover;
-  background-position: center;
+  background: var(--chat-body-background, var(--chat-background-color));
+  background-size: var(--chat-body-background-size, cover);
+  background-position: var(--chat-body-background-position, center);
+  background-repeat: var(--chat-body-background-repeat, repeat);
+  background-attachment: var(--chat-body-background-attachment, scroll);
 }
 
 .chat-overlay {
@@ -50,33 +147,71 @@ body {
   max-width: 500px;
   height: 100%;
   max-height: 80vh;
-  background: var(--chat-box-background-color);
-  border-radius: 12px;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.25);
-  padding: 20px;
+  background: var(--chat-box-background, var(--chat-box-background-color));
+  border-radius: var(--chat-box-border-radius, 12px);
+  border: var(--chat-box-border, none);
+  box-shadow: var(--chat-box-box-shadow, 0 4px 15px rgba(0, 0, 0, 0.25));
+  padding: var(--chat-box-padding, 20px);
   box-sizing: border-box;
+  overflow: var(--chat-box-overflow, visible);
 }
 
 .chat-box header {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-bottom: 10px;
+  margin-bottom: var(--chat-header-margin-bottom, 10px);
+  padding: var(--chat-header-padding, 0);
+  background: var(--chat-header-background, transparent);
+  border-bottom: var(--chat-header-border-bottom, none);
+  text-align: var(--chat-header-text-align, inherit);
+  flex-direction: var(--chat-header-flex-direction, row);
 }
 
 .chat-box header img {
-  max-width: 80%;
+  max-width: var(--chat-header-logo-max-width, 80%);
   height: auto;
+  display: var(--chat-header-logo-display, block);
+  margin: var(--chat-header-logo-margin, 0 auto);
+  filter: var(--chat-header-logo-filter, none);
+}
+
+.brand-claim {
+  color: var(--brand-claim-color, inherit);
+  font-size: var(--brand-claim-font-size, 0.85rem);
+  letter-spacing: var(--brand-claim-letter-spacing, normal);
+  text-transform: var(--brand-claim-text-transform, none);
+  margin-top: var(--brand-claim-margin-top, 0);
+  text-align: var(--brand-claim-text-align, center);
 }
 
 #chat-log {
   flex: 1;
+  display: var(--chat-log-display, flex);
+  flex-direction: var(--chat-log-flex-direction, column);
+  gap: var(--chat-log-gap, 8px);
   overflow-y: auto;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  padding: 10px;
-  margin-bottom: 10px;
-  background: #fff;
+  border: var(--chat-log-border, 1px solid #ddd);
+  border-radius: var(--chat-log-border-radius, 4px);
+  padding: var(--chat-log-padding, 10px);
+  margin-bottom: var(--chat-log-margin-bottom, 10px);
+  background: var(--chat-log-background, #fff);
+  box-sizing: border-box;
+}
+
+#chat-log a {
+  color: var(--chat-log-link-color, var(--chat-link-color));
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-thickness: var(--chat-log-link-decoration-thickness, auto);
+}
+
+#chat-log a:hover {
+  text-decoration: none;
+}
+
+#chat-log ul {
+  padding-left: var(--chat-log-list-padding-left, 20px);
 }
 
 .message {
@@ -105,11 +240,19 @@ body {
 
 .chat-controls input[type="text"] {
   width: 100%;
-  padding: 8px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  padding: var(--chat-input-padding, 8px);
+  border: var(--chat-input-border, 1px solid #ccc);
+  border-radius: var(--chat-input-border-radius, 4px);
   box-sizing: border-box;
   margin-bottom: 6px;
+  font-size: var(--chat-input-font-size, 1em);
+  letter-spacing: var(--chat-input-letter-spacing, normal);
+}
+
+.chat-controls input[type="text"]:focus {
+  outline: var(--chat-input-focus-outline, auto);
+  box-shadow: var(--chat-input-focus-box-shadow, none);
+  border-color: var(--chat-input-focus-border-color, #ccc);
 }
 
 .chat-controls .privacy {
@@ -117,6 +260,7 @@ body {
   align-items: center;
   margin-bottom: 6px;
   font-size: 0.9em;
+  color: var(--chat-privacy-color, inherit);
 }
 
 .chat-controls .privacy input[type="checkbox"] {
@@ -134,17 +278,19 @@ body {
 }
 
 .chat-controls button {
-  padding: 8px;
-  border: none;
-  border-radius: 4px;
-  background: var(--chat-primary-color);
-  color: var(--chat-primary-text-color);
+  padding: var(--chat-button-padding, 8px);
+  border: var(--chat-button-border, none);
+  border-radius: var(--chat-button-border-radius, 4px);
+  background: var(--chat-button-background, var(--chat-primary-color));
+  color: var(--chat-button-color, var(--chat-primary-text-color));
   cursor: pointer;
   font-size: 1em;
+  letter-spacing: var(--chat-button-letter-spacing, normal);
 }
 
 .chat-controls button:disabled {
-  background: #999;
+  background: var(--chat-button-disabled-background, #999);
+  border: var(--chat-button-disabled-border, none);
   cursor: not-allowed;
 }
 
@@ -152,12 +298,13 @@ body {
   position: fixed;
   bottom: 15px;
   right: 15px;
-  background: rgba(0, 0, 0, 0.6);
-  color: #fff;
+  background: var(--return-link-background, rgba(0, 0, 0, 0.6));
+  color: var(--return-link-color, #fff);
   padding: 8px 12px;
   border-radius: 6px;
   text-decoration: none;
   font-size: 0.9em;
+  border: var(--return-link-border, none);
 }
 
 .return-link:hover {
@@ -258,24 +405,18 @@ body {
 }
 
 /* Chatblasen-Grundlayout */
-#chat-log {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px;
-}
-
-/* Gemeinsame Basis */
 .msg {
   display: flex;
   width: 100%;
 }
 
 .msg .bubble {
-  max-width: 70%;
-  padding: 8px 12px;
-  border-radius: 12px;
-  line-height: 1.4;
+  max-width: var(--chat-msg-bubble-max-width, 70%);
+  padding: var(--chat-msg-bubble-padding, 8px 12px);
+  border-radius: var(--chat-msg-bubble-border-radius, 12px);
+  line-height: var(--chat-msg-bubble-line-height, 1.4);
+  font-size: var(--chat-msg-bubble-font-size, inherit);
+  letter-spacing: var(--chat-msg-bubble-letter-spacing, normal);
 }
 
 /* Bot (links) */
@@ -283,9 +424,10 @@ body {
   justify-content: flex-start;
 }
 .msg.bot .bubble {
-  background: var(--chat-bot-bubble-color);
-  color: var(--chat-bot-text-color);
-  border-top-left-radius: 0;
+  background: var(--chat-msg-bot-background, var(--chat-bot-bubble-color));
+  color: var(--chat-msg-bot-color, var(--chat-bot-text-color));
+  border-top-left-radius: var(--chat-msg-bot-border-top-left-radius, 0);
+  border: var(--chat-msg-bot-border, none);
 }
 
 /* User (rechts) */
@@ -293,10 +435,19 @@ body {
   justify-content: flex-end;
 }
 .msg.user .bubble {
-  background: var(--chat-user-bubble-color);
-  color: var(--chat-user-text-color);
-  border-top-right-radius: 0;
-  text-align: right;
+  background: var(--chat-msg-user-background, var(--chat-user-bubble-color));
+  color: var(--chat-msg-user-color, var(--chat-user-text-color));
+  border-top-right-radius: var(--chat-msg-user-border-top-right-radius, 0);
+  text-align: var(--chat-msg-user-text-align, right);
+  border: var(--chat-msg-user-border, none);
+  letter-spacing: var(--chat-msg-user-letter-spacing, normal);
+}
+
+.msg .bubble strong {
+  font-weight: var(--chat-msg-strong-font-weight, 600);
+  letter-spacing: var(--chat-msg-strong-letter-spacing, normal);
+  opacity: var(--chat-msg-strong-opacity, 1);
+  margin-right: var(--chat-msg-strong-margin-right, 0);
 }
 
 

--- a/faehrhaus/assets/css/hotel.css
+++ b/faehrhaus/assets/css/hotel.css
@@ -14,143 +14,98 @@
   font-style: normal;
   font-display: swap;
 }
+
 :root {
   --fh-ink: #2D393B;            /* Primärschrift-/Linienfarbe */
   --fh-ink-80: rgba(45,57,59,.8);
   --fh-ink-20: rgba(45,57,59,.2);
   --fh-accent: #2D393B;         /* Akzent bleibt tonal */
-  --fh-bg: rgb(45,57,59);             /* grauer Hintergrund */
+  --fh-bg: rgb(45,57,59);       /* grauer Hintergrund */
   --fh-bubble-user: #2D393B;    /* User-Blase dunkel (negativ, weiße Schrift) */
   --fh-bubble-bot: #F3F5F5;     /* Sehr helles Grau mit leichter Blaugrün-Note */
   --fh-focus: #2D393B;
-}
 
-html, body {
-  font-family: "FuturaCustom", "Futura", "Futura PT", "Avenir Next", "Helvetica Neue", Arial, sans-serif;
-  color: var(--fh-ink);
-  background: url('../images/background.jpg') no-repeat center center fixed !important;
-  background-size: cover !important;
-}
+  --chat-font-family: "FuturaCustom", "Futura", "Futura PT", "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  --chat-text-color: var(--fh-ink);
+  --chat-body-background: url('../images/background.jpg') no-repeat center center fixed;
+  --chat-body-background-size: cover;
+  --chat-body-background-position: center;
+  --chat-body-background-repeat: no-repeat;
+  --chat-body-background-attachment: fixed;
 
-/* Grundlayout (Core überschreiben) */
-.chat-box {
-  background: var(--fh-bg);
-  border-radius: 14px;
-  box-shadow: 0 8px 28px rgba(0,0,0,.12);
-  border: 1px solid var(--fh-ink-20);
-}
+  --chat-box-background: var(--fh-bg);
+  --chat-box-border-radius: 14px;
+  --chat-box-border: 1px solid var(--fh-ink-20);
+  --chat-box-box-shadow: 0 8px 28px rgba(0,0,0,.12);
 
-/* Header mit Logo + optionalem Claim */
-.chat-box header {
-  padding: 6px 0 10px;
-  border-bottom: 1px solid var(--fh-ink-20);
-  margin-bottom: 10px;
-}
-.chat-box header img {
-  max-width: 220px;
-  height: auto;
-  display: block;
-  margin: 0 auto 6px auto;
-  filter: none; /* Logo unverfälscht anzeigen */
-}
-.brand-claim {
-  font-size: 10px;
-  letter-spacing: .18em;      /* Headlines 100–200 → 0.10–0.20em */
-  text-align: center;
-  color: var(--fh-ink-80);
-  margin-top: 2px;
-}
+  --chat-header-padding: 6px 0 10px;
+  --chat-header-border-bottom: 1px solid var(--fh-ink-20);
+  --chat-header-text-align: center;
+  --chat-header-logo-max-width: 220px;
+  --chat-header-logo-display: block;
+  --chat-header-logo-margin: 0 auto 6px auto;
 
-/* Chatbereich */
-#chat-log {
-  background: #fff;
-  border: 1px solid var(--fh-ink-20);
-  border-radius: 10px;
-}
+  --brand-claim-font-size: 10px;
+  --brand-claim-letter-spacing: .18em;      /* Headlines 100–200 → 0.10–0.20em */
+  --brand-claim-text-align: center;
+  --brand-claim-color: var(--fh-ink-80);
+  --brand-claim-margin-top: 2px;
 
-/* Bubbles – links (Bot) / rechts (User) im Messenger-Stil */
-.msg { display: flex; width: 100%; }
-.msg .bubble {
-  max-width: 78%;
-  padding: 10px 14px;
-  border-radius: 14px;
-  line-height: 1.5;
-  font-size: 14.5px;           /* Fließtext ~12pt → ca. 16px; hier minimal kleiner, wirkt eleganter */
-  letter-spacing: .02em;       /* Fließtext Laufweite ~50 → ~0.05em; wir gehen moderat */
-}
+  --chat-log-border: 1px solid var(--fh-ink-20);
+  --chat-log-border-radius: 10px;
 
-/* Bot (links, positiv) */
-.msg.bot { justify-content: flex-start; }
-.msg.bot .bubble {
-  background: var(--fh-bubble-bot);
-  color: var(--fh-ink);
-  border-top-left-radius: 4px;
-  border: 1px solid var(--fh-ink-20);
-}
+  --chat-msg-bubble-max-width: 78%;
+  --chat-msg-bubble-padding: 10px 14px;
+  --chat-msg-bubble-border-radius: 14px;
+  --chat-msg-bubble-line-height: 1.5;
+  --chat-msg-bubble-font-size: 14.5px;
+  --chat-msg-bubble-letter-spacing: .02em;
 
-/* User (rechts, negativ) */
-.msg.user { justify-content: flex-end; }
-.msg.user .bubble {
-  background: var(--fh-bubble-user);
-  color: #fff;
-  border-top-right-radius: 4px;
-  letter-spacing: .03em;       /* etwas mehr Tracking für Negativschrift */
-  text-align: right;
-  border: 1px solid var(--fh-ink);
-}
+  --chat-msg-bot-background: var(--fh-bubble-bot);
+  --chat-msg-bot-color: var(--fh-ink);
+  --chat-msg-bot-border-top-left-radius: 4px;
+  --chat-msg-bot-border: 1px solid var(--fh-ink-20);
 
-/* Labels „Max:“ / „Du:“ zurückhaltend (Book/Medium) */
-.msg .bubble strong {
-  letter-spacing: .05em;
-  font-weight: 500;            /* Medium */
-  display: inline-block;
-  margin-right: .35em;
-  opacity: .9;
-}
+  --chat-msg-user-background: var(--fh-bubble-user);
+  --chat-msg-user-color: #fff;
+  --chat-msg-user-border-top-right-radius: 4px;
+  --chat-msg-user-border: 1px solid var(--fh-ink);
+  --chat-msg-user-letter-spacing: .03em;       /* etwas mehr Tracking für Negativschrift */
 
-/* Eingabe + Buttons */
-.chat-controls input[type="text"] {
-  border: 1px solid var(--fh-ink-20);
-  border-radius: 10px;
-  padding: 12px 14px;
-  font-size: 15px;
-  letter-spacing: .02em;
-}
-.chat-controls input[type="text"]:focus {
-  outline: 2px solid transparent;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--fh-focus) 30%, transparent);
-  border-color: var(--fh-focus);
-}
-.chat-controls .privacy {
-  color: white;
-}
-.chat-controls button {
-  background: #fff;
-  color: var(--fh-ink);
-  border-radius: 10px;
-  padding: 10px 14px;
-  letter-spacing: .06em;       /* leichter „Button“-Look */
-}
-.chat-controls button:disabled {
-  background: #9AA3A5;
-}
+  --chat-msg-strong-font-weight: 500;          /* Medium */
+  --chat-msg-strong-letter-spacing: .05em;
+  --chat-msg-strong-margin-right: .35em;
+  --chat-msg-strong-opacity: .9;
 
-/* Sekundäre Elemente */
-.return-link {
-  background: rgba(45,57,59, .85);
-  border: 1px solid var(--fh-ink);
-}
+  --chat-input-border: 1px solid var(--fh-ink-20);
+  --chat-input-border-radius: 10px;
+  --chat-input-padding: 12px 14px;
+  --chat-input-font-size: 15px;
+  --chat-input-letter-spacing: .02em;
+  --chat-input-focus-outline: 2px solid transparent;
+  --chat-input-focus-box-shadow: 0 0 0 3px color-mix(in srgb, var(--fh-focus) 30%, transparent);
+  --chat-input-focus-border-color: var(--fh-focus);
 
-/* Kleintypografie im Log (Links, Listen) */
-#chat-log a {
-  color: var(--fh-ink);
-  text-decoration-thickness: 1px;
+  --chat-privacy-color: #ffffff;
+
+  --chat-button-background: #fff;
+  --chat-button-color: var(--fh-ink);
+  --chat-button-border-radius: 10px;
+  --chat-button-padding: 10px 14px;
+  --chat-button-letter-spacing: .06em;       /* leichter „Button“-Look */
+  --chat-button-disabled-background: #9AA3A5;
+
+  --return-link-background: rgba(45,57,59, .85);
+  --return-link-border: 1px solid var(--fh-ink);
+
+  --chat-log-link-color: var(--fh-ink);
+  --chat-log-link-decoration-thickness: 1px;
+  --chat-log-list-padding-left: 1.2em;
 }
-#chat-log ul { padding-left: 1.2em; }
 
 /* Headline-Typo – falls irgendwo Überschriften auftauchen */
 h1, h2, h3 {
-  text-transform: uppercase; 
+  text-transform: uppercase;
   letter-spacing: .14em;      /* 100–200 → 0.10–0.20em, mittig gewählt */
   font-weight: 500;           /* Book/Medium */
 }

--- a/roth/assets/css/hotel.css
+++ b/roth/assets/css/hotel.css
@@ -1,140 +1,94 @@
-:root{
+:root {
   --ah-ink: #000;           /* dunkles Blaugrün für Texte, Linien */
   --ah-ink-80: #ae2a23ce;
   --ah-ink-20: #ae2a234a;
-  --ah-brand: #ae2b23;         /* Hotel Roth Akzent/Brand (Teal) */
+  --ah-brand: #ae2b23;         /* Hotel Roth Akzent/Brand */
   --ah-bg: #FFFFFF;            /* Grundfläche */
   --ah-bubble-user: #ae2b23;   /* User-Bubble (negativ/weiß) */
   --ah-bubble-bot: #F1F6F7;    /* sehr hell, leicht bläulich */
-  --ah-header: #ae2b23;        /* sehr dunkler Header für weißes Logo */
+  --ah-header: #ae2b23;        /* Headerfarbe */
   --ah-focus: #ae2b23;
-}
 
-/* Typo: eleganter Sans-Serif-Fallback; wenn ihr Branding-Fonts habt, hier einbinden */
-html, body{
-  font-family: "Avenir Next","Helvetica Neue",Arial,sans-serif;
-  color: var(--ah-ink);
-  background: url('../images/background.jpg') no-repeat center center fixed!important;
-  background-size: cover !important;
-}
+  --chat-font-family: "Avenir Next","Helvetica Neue",Arial,sans-serif;
+  --chat-text-color: var(--ah-ink);
+  --chat-body-background: url('../images/background.jpg') no-repeat center center fixed;
+  --chat-body-background-size: cover;
+  --chat-body-background-position: center;
+  --chat-body-background-repeat: no-repeat;
+  --chat-body-background-attachment: fixed;
 
+  --chat-box-background: #fff;
+  --chat-box-border-radius: 14px;
+  --chat-box-border: 1px solid var(--ah-ink-20);
+  --chat-box-box-shadow: 0 8px 28px rgba(0,0,0,.10);
+  --chat-box-overflow: hidden;
 
+  --chat-header-background: var(--ah-header);
+  --chat-header-padding: 14px 0 12px;
+  --chat-header-border-bottom: 1px solid rgba(255,255,255,.12);
+  --chat-header-text-align: center;
+  --chat-header-logo-max-width: 210px;
+  --chat-header-logo-display: inline-block;
+  --chat-header-logo-margin: 0;
 
-/* Chat-Container */
-.chat-box{
-  background: #fff;
-  border-radius: 14px;
-  box-shadow: 0 8px 28px rgba(0,0,0,.10);
-  border: 1px solid var(--ah-ink-20);
-  overflow: hidden; /* damit Header oben bündig ist */
-}
+  --brand-claim-color: rgba(255,255,255,.9);
+  --brand-claim-font-size: 11px;
+  --brand-claim-letter-spacing: .12em;
+  --brand-claim-text-transform: uppercase;
+  --brand-claim-margin-top: 4px;
 
-/* Header mit dunklem Balken für weißes Logo */
-.chat-box header{
-  background: var(--ah-header);
-  padding: 14px 0 12px;
-  border-bottom: 1px solid rgba(255,255,255,.12);
-  margin-bottom: 10px;
-  text-align: center;
-}
-.chat-box header img{
-  max-width: 210px;
-  height: auto;
-  display: inline-block;
-  filter: none; /* weißes Logo unverändert */
-}
+  --chat-log-border: 1px solid var(--ah-ink-20);
+  --chat-log-border-radius: 10px;
+  --chat-log-gap: 8px;
+  --chat-log-padding: 10px;
 
-/* Optionaler Claim unter dem Logo (falls gewünscht) */
-.brand-claim{
-  color: rgba(255,255,255,.9);
-  font-size: 11px;
-  letter-spacing: .12em;
-  text-transform: uppercase;
-  margin-top: 4px;
-}
+  --chat-msg-bubble-max-width: 78%;
+  --chat-msg-bubble-padding: 10px 14px;
+  --chat-msg-bubble-border-radius: 14px;
+  --chat-msg-bubble-line-height: 1.5;
+  --chat-msg-bubble-font-size: 15px;
+  --chat-msg-bubble-letter-spacing: .01em;
 
-/* Chatbereich */
-#chat-log{
-  background: #fff;
-  border: 1px solid var(--ah-ink-20);
-  border-radius: 10px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px;
-}
+  --chat-msg-bot-background: var(--ah-bubble-bot);
+  --chat-msg-bot-color: var(--ah-ink);
+  --chat-msg-bot-border-top-left-radius: 4px;
+  --chat-msg-bot-border: 1px solid var(--ah-ink-20);
 
-/* Bubbles – Bot links, User rechts */
-.msg{ display:flex; width:100%; }
-.msg .bubble{
-  max-width: 78%;
-  padding: 10px 14px;
-  border-radius: 14px;
-  line-height: 1.5;
-  font-size: 15px;
-  letter-spacing: .01em;
-}
+  --chat-msg-user-background: var(--ah-bubble-user);
+  --chat-msg-user-color: #fff;
+  --chat-msg-user-border-top-right-radius: 4px;
+  --chat-msg-user-border: 1px solid color-mix(in srgb, var(--ah-bubble-user) 70%, #000 30%);
+  --chat-msg-user-text-align: right;
 
-/* Bot (links, positiv) */
-.msg.bot{ justify-content:flex-start; }
-.msg.bot .bubble{
-  background: var(--ah-bubble-bot);
-  color: var(--ah-ink);
-  border-top-left-radius: 4px;
-  border: 1px solid var(--ah-ink-20);
-}
+  --chat-msg-strong-font-weight: 600;
+  --chat-msg-strong-letter-spacing: .04em;
+  --chat-msg-strong-opacity: .95;
+  --chat-msg-strong-margin-right: .35em;
 
-/* User (rechts, negativ/weiß) */
-.msg.user{ justify-content:flex-end; }
-.msg.user .bubble{
-  background: var(--ah-bubble-user);
-  color: #fff;
-  border-top-right-radius: 4px;
-  border: 1px solid color-mix(in srgb, var(--ah-bubble-user) 70%, #000 30%);
-  text-align: right;
-}
+  --chat-input-border: 1px solid var(--ah-ink-20);
+  --chat-input-border-radius: 10px;
+  --chat-input-padding: 12px 14px;
+  --chat-input-font-size: 15px;
+  --chat-input-focus-outline: 2px solid transparent;
+  --chat-input-focus-box-shadow: 0 0 0 3px color-mix(in srgb, var(--ah-focus) 25%, transparent);
+  --chat-input-focus-border-color: var(--ah-focus);
 
-/* Labels „Max:“ / „Du:“ zurückhaltend */
-.msg .bubble strong{
-  font-weight: 600;
-  letter-spacing: .04em;
-  opacity: .95;
-  margin-right: .35em;
-}
+  --chat-privacy-color: var(--ah-ink-80);
 
-/* Eingabe & Buttons */
-.chat-controls input[type="text"]{
-  border: 1px solid var(--ah-ink-20);
-  border-radius: 10px;
-  padding: 12px 14px;
-  font-size: 15px;
-}
-.chat-controls input[type="text"]:focus{
-  outline: 2px solid transparent;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ah-focus) 25%, transparent);
-  border-color: var(--ah-focus);
-}
-.chat-controls .privacy{ color: var(--ah-ink-80); }
-.chat-controls button{
-  background: var(--ah-brand);
-  color: #fff;
-  border-radius: 10px;
-  padding: 10px 14px;
-  letter-spacing: .03em;
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
-}
-.chat-controls button:disabled{
-  background: #9FB8C1;
-  border-color: #9FB8C1;
-}
+  --chat-button-background: var(--ah-brand);
+  --chat-button-color: #fff;
+  --chat-button-border-radius: 10px;
+  --chat-button-padding: 10px 14px;
+  --chat-button-letter-spacing: .03em;
+  --chat-button-border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
+  --chat-button-disabled-background: #9FB8C1;
+  --chat-button-disabled-border: 1px solid #9FB8C1;
 
-/* „Zurück zur Website“-Button */
-.return-link{
-  background: rgba(15,110,143,.9);
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
-  color: #fff;
-}
+  --return-link-background: rgba(15,110,143,.9);
+  --return-link-border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
+  --return-link-color: #fff;
 
-/* Links im Chat */
-#chat-log a{ color: var(--ah-brand); text-decoration-thickness: 1px; }
-#chat-log ul{ padding-left: 1.2em; }
+  --chat-log-link-color: var(--ah-brand);
+  --chat-log-link-decoration-thickness: 1px;
+  --chat-log-list-padding-left: 1.2em;
+}


### PR DESCRIPTION
## Summary
- extend the core stylesheet with customizable CSS variables for shared chat layout elements
- move shared styling from the hotel-specific stylesheets into variable assignments to eliminate duplication

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2b1e463348324a1664848c22b2c06