### PR TITLE
Refactor CSS layering for shared variables

### DIFF
--- a/aarnhoog/assets/css/hotel.css
+++ b/aarnhoog/assets/css/hotel.css
@@ -1,146 +1,80 @@
 /*
  * AARNHOOG – hotelspezifische Stile
- * Annahme: Logo ist WEISS (transparent) → dunkler Header-Hintergrund.
- * Farbschema: ruhiges Nordsee-Teal als Primärfarbe, warmes Offwhite als Fläche.
+ * Individuelle Farben, Typografie und Detailanpassungen.
  */
 
-:root{
-  --ah-ink: #123C48;           /* dunkles Blaugrün für Texte, Linien */
-  --ah-ink-80: rgba(18,60,72,.85);
-  --ah-ink-20: rgba(18,60,72,.2);
-  --ah-brand: #0F6E8F;         /* Aarnhoog Akzent/Brand (Teal) */
-  --ah-bg: #FFFFFF;            /* Grundfläche */
-  --ah-bubble-user: #0F6E8F;   /* User-Bubble (negativ/weiß) */
-  --ah-bubble-bot: #F1F6F7;    /* sehr hell, leicht bläulich */
-  --ah-header: #0D2C33;        /* sehr dunkler Header für weißes Logo */
-  --ah-focus: #0F6E8F;
+:root {
+  --ah-ink: #123c48;
+  --ah-ink-80: rgba(18, 60, 72, 0.85);
+  --ah-ink-20: rgba(18, 60, 72, 0.2);
+  --ah-brand: #0f6e8f;
+
+  --chat-font-family: "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  --chat-text-color: var(--ah-ink);
+  --chat-background-image: url('../images/background.jpg');
+  --chat-background-attachment: fixed;
+
+  --chat-primary-color: var(--ah-brand);
+  --chat-primary-text-color: #ffffff;
+  --chat-link-color: var(--ah-brand);
+
+  --chat-box-background: #ffffff;
+  --chat-box-border: 1px solid var(--ah-ink-20);
+  --chat-box-border-radius: 14px;
+  --chat-box-shadow: 0 8px 28px rgba(0, 0, 0, 0.1);
+  --chat-box-overflow: hidden;
+
+  --chat-header-background: #0d2c33;
+  --chat-header-padding: 14px 0 12px;
+  --chat-header-border: 1px solid rgba(255, 255, 255, 0.12);
+  --chat-logo-max-width: 210px;
+  --chat-claim-color: rgba(255, 255, 255, 0.9);
+
+  --chat-log-border: 1px solid var(--ah-ink-20);
+  --chat-log-border-radius: 10px;
+  --chat-log-gap: 8px;
+
+  --chat-bubble-max-width: 78%;
+  --chat-bubble-padding: 10px 14px;
+  --chat-bubble-border-radius: 14px;
+  --chat-bubble-letter-spacing: 0.01em;
+  --chat-bubble-line-height: 1.5;
+  --chat-bot-bubble-color: #f1f6f7;
+  --chat-bot-text-color: var(--ah-ink);
+  --chat-bot-bubble-border: 1px solid var(--ah-ink-20);
+  --chat-user-bubble-color: var(--ah-brand);
+  --chat-user-text-color: #ffffff;
+  --chat-user-bubble-border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
+
+  --chat-input-border: 1px solid var(--ah-ink-20);
+  --chat-input-border-radius: 10px;
+  --chat-input-padding: 12px 14px;
+  --chat-input-font-size: 15px;
+  --chat-input-focus-shadow: 0 0 0 3px color-mix(in srgb, var(--ah-brand) 25%, transparent);
+  --chat-input-focus-border-color: var(--ah-brand);
+
+  --chat-privacy-color: var(--ah-ink-80);
+
+  --chat-button-background: var(--ah-brand);
+  --chat-button-border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
+  --chat-button-border-radius: 10px;
+  --chat-button-padding: 10px 14px;
+  --chat-button-letter-spacing: 0.03em;
+  --chat-button-disabled-background: #9fb8c1;
+  --chat-button-disabled-border: 1px solid #9fb8c1;
+
+  --chat-return-link-background: rgba(15, 110, 143, 0.9);
+  --chat-return-link-border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
 }
 
-/* Typo: eleganter Sans-Serif-Fallback; wenn ihr Branding-Fonts habt, hier einbinden */
-html, body{
-  font-family: "Avenir Next","Helvetica Neue",Arial,sans-serif;
-  color: var(--ah-ink);
-  background: url('../images/background.jpg') no-repeat center center fixed!important;
-  background-size: cover !important;
-}
-
-
-
-/* Chat-Container */
-.chat-box{
-  background: #fff;
-  border-radius: 14px;
-  box-shadow: 0 8px 28px rgba(0,0,0,.10);
-  border: 1px solid var(--ah-ink-20);
-  overflow: hidden; /* damit Header oben bündig ist */
-}
-
-/* Header mit dunklem Balken für weißes Logo */
-.chat-box header{
-  background: var(--ah-header);
-  padding: 14px 0 12px;
-  border-bottom: 1px solid rgba(255,255,255,.12);
-  margin-bottom: 10px;
-  text-align: center;
-}
-.chat-box header img{
-  max-width: 210px;
-  height: auto;
-  display: inline-block;
-  filter: none; /* weißes Logo unverändert */
-}
-
-/* Optionaler Claim unter dem Logo (falls gewünscht) */
-.brand-claim{
-  color: rgba(255,255,255,.9);
-  font-size: 11px;
-  letter-spacing: .12em;
-  text-transform: uppercase;
-  margin-top: 4px;
-}
-
-/* Chatbereich */
-#chat-log{
-  background: #fff;
-  border: 1px solid var(--ah-ink-20);
-  border-radius: 10px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px;
-}
-
-/* Bubbles – Bot links, User rechts */
-.msg{ display:flex; width:100%; }
-.msg .bubble{
-  max-width: 78%;
-  padding: 10px 14px;
-  border-radius: 14px;
-  line-height: 1.5;
-  font-size: 15px;
-  letter-spacing: .01em;
-}
-
-/* Bot (links, positiv) */
-.msg.bot{ justify-content:flex-start; }
-.msg.bot .bubble{
-  background: var(--ah-bubble-bot);
-  color: var(--ah-ink);
-  border-top-left-radius: 4px;
-  border: 1px solid var(--ah-ink-20);
-}
-
-/* User (rechts, negativ/weiß) */
-.msg.user{ justify-content:flex-end; }
-.msg.user .bubble{
-  background: var(--ah-bubble-user);
-  color: #fff;
-  border-top-right-radius: 4px;
-  border: 1px solid color-mix(in srgb, var(--ah-bubble-user) 70%, #000 30%);
-  text-align: right;
-}
-
-/* Labels „Max:“ / „Du:“ zurückhaltend */
-.msg .bubble strong{
+/* Spezifische Mikrotypografie */
+.msg .bubble strong {
   font-weight: 600;
-  letter-spacing: .04em;
-  opacity: .95;
-  margin-right: .35em;
+  letter-spacing: 0.04em;
+  opacity: 0.95;
+  margin-right: 0.35em;
 }
 
-/* Eingabe & Buttons */
-.chat-controls input[type="text"]{
-  border: 1px solid var(--ah-ink-20);
-  border-radius: 10px;
-  padding: 12px 14px;
-  font-size: 15px;
+#chat-log a {
+  text-decoration-thickness: 1px;
 }
-.chat-controls input[type="text"]:focus{
-  outline: 2px solid transparent;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ah-focus) 25%, transparent);
-  border-color: var(--ah-focus);
-}
-.chat-controls .privacy{ color: var(--ah-ink-80); }
-.chat-controls button{
-  background: var(--ah-brand);
-  color: #fff;
-  border-radius: 10px;
-  padding: 10px 14px;
-  letter-spacing: .03em;
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
-}
-.chat-controls button:disabled{
-  background: #9FB8C1;
-  border-color: #9FB8C1;
-}
-
-/* „Zurück zur Website“-Button */
-.return-link{
-  background: rgba(15,110,143,.9);
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
-  color: #fff;
-}
-
-/* Links im Chat */
-#chat-log a{ color: var(--ah-brand); text-decoration-thickness: 1px; }
-#chat-log ul{ padding-left: 1.2em; }

--- a/core/assets/css/style.css
+++ b/core/assets/css/style.css
@@ -8,26 +8,105 @@
 
 :root {
   --chat-background-color: #f0f0f0;
-  --chat-box-background-color: #808080;
+  --chat-background-image: none;
+  --chat-background-size: cover;
+  --chat-background-position: center;
+  --chat-background-repeat: no-repeat;
+  --chat-background-attachment: scroll;
+
+  --chat-font-family: Arial, Helvetica, sans-serif;
+  --chat-text-color: #0f172a;
+
+  --chat-box-background: #ffffff;
+  --chat-box-border: none;
+  --chat-box-border-radius: 12px;
+  --chat-box-shadow: 0 4px 15px rgba(0, 0, 0, 0.25);
+  --chat-box-padding: 20px;
+  --chat-box-overflow: visible;
+
   --chat-primary-color: #003366;
   --chat-primary-text-color: #ffffff;
   --chat-link-color: var(--chat-primary-color);
+
   --chat-user-bubble-color: #0078d7;
   --chat-user-text-color: #ffffff;
   --chat-bot-bubble-color: #f0f0f0;
   --chat-bot-text-color: #000000;
+
+  --chat-header-background: transparent;
+  --chat-header-border: none;
+  --chat-header-padding: 0;
+  --chat-header-margin-bottom: 10px;
+  --chat-header-text-align: center;
+  --chat-logo-max-width: 80%;
+  --chat-logo-filter: none;
+
+  --chat-claim-color: var(--chat-primary-color);
+  --chat-claim-font-size: 11px;
+  --chat-claim-letter-spacing: 0.12em;
+  --chat-claim-text-transform: uppercase;
+  --chat-claim-margin-top: 4px;
+
+  --chat-log-background: #ffffff;
+  --chat-log-border: 1px solid #ddd;
+  --chat-log-border-radius: 4px;
+  --chat-log-gap: 8px;
+  --chat-log-padding: 10px;
+
+  --chat-bubble-max-width: 70%;
+  --chat-bubble-padding: 8px 12px;
+  --chat-bubble-border-radius: 12px;
+  --chat-bubble-font-size: 15px;
+  --chat-bubble-letter-spacing: 0;
+  --chat-bubble-line-height: 1.4;
+
+  --chat-bot-bubble-border: 1px solid transparent;
+  --chat-user-bubble-border: 1px solid transparent;
+  --chat-user-text-align: right;
+  --chat-user-letter-spacing: 0;
+
+  --chat-input-border: 1px solid #ccc;
+  --chat-input-border-radius: 4px;
+  --chat-input-padding: 8px;
+  --chat-input-font-size: 1em;
+  --chat-input-focus-outline: 2px solid transparent;
+  --chat-input-focus-shadow: none;
+  --chat-input-focus-border-color: var(--chat-primary-color);
+
+  --chat-privacy-color: inherit;
+
+  --chat-button-background: var(--chat-primary-color);
+  --chat-button-color: var(--chat-primary-text-color);
+  --chat-button-border: none;
+  --chat-button-border-radius: 4px;
+  --chat-button-padding: 8px;
+  --chat-button-letter-spacing: 0;
+  --chat-button-disabled-background: #999;
+  --chat-button-disabled-border: none;
+
+  --chat-return-link-background: rgba(0, 0, 0, 0.6);
+  --chat-return-link-color: #ffffff;
+  --chat-return-link-border: none;
+
+  --chat-link-decoration: underline;
+  --chat-link-decoration-hover: none;
 }
 
-html, body {
+html,
+body {
   height: 100%;
   margin: 0;
-  font-family: Arial, Helvetica, sans-serif;
 }
 
 body {
-  background: var(--chat-background-color);
-  background-size: cover;
-  background-position: center;
+  font-family: var(--chat-font-family);
+  color: var(--chat-text-color);
+  background-color: var(--chat-background-color);
+  background-image: var(--chat-background-image);
+  background-size: var(--chat-background-size);
+  background-position: var(--chat-background-position);
+  background-repeat: var(--chat-background-repeat);
+  background-attachment: var(--chat-background-attachment);
 }
 
 .chat-overlay {
@@ -50,42 +129,62 @@ body {
   max-width: 500px;
   height: 100%;
   max-height: 80vh;
-  background: var(--chat-box-background-color);
-  border-radius: 12px;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.25);
-  padding: 20px;
+  background: var(--chat-box-background);
+  border: var(--chat-box-border);
+  border-radius: var(--chat-box-border-radius);
+  box-shadow: var(--chat-box-shadow);
+  padding: var(--chat-box-padding);
   box-sizing: border-box;
+  overflow: var(--chat-box-overflow);
 }
 
 .chat-box header {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
-  margin-bottom: 10px;
+  gap: 6px;
+  background: var(--chat-header-background);
+  padding: var(--chat-header-padding);
+  border-bottom: var(--chat-header-border);
+  margin-bottom: var(--chat-header-margin-bottom);
+  text-align: var(--chat-header-text-align);
 }
 
 .chat-box header img {
-  max-width: 80%;
+  max-width: var(--chat-logo-max-width);
   height: auto;
+  filter: var(--chat-logo-filter);
+}
+
+.brand-claim {
+  color: var(--chat-claim-color);
+  font-size: var(--chat-claim-font-size);
+  letter-spacing: var(--chat-claim-letter-spacing);
+  text-transform: var(--chat-claim-text-transform);
+  margin-top: var(--chat-claim-margin-top);
 }
 
 #chat-log {
   flex: 1;
   overflow-y: auto;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  padding: 10px;
+  border: var(--chat-log-border);
+  border-radius: var(--chat-log-border-radius);
+  padding: var(--chat-log-padding);
   margin-bottom: 10px;
-  background: #fff;
+  background: var(--chat-log-background);
+  display: flex;
+  flex-direction: column;
+  gap: var(--chat-log-gap);
 }
 
 .message {
-  margin-bottom: 8px;
-  line-height: 1.4;
+  margin-bottom: var(--chat-log-gap);
+  line-height: var(--chat-bubble-line-height);
 }
 
 .message.user {
-  text-align: right;
+  text-align: var(--chat-user-text-align);
   color: var(--chat-primary-color);
 }
 
@@ -98,18 +197,38 @@ body {
   font-style: italic;
   color: var(--chat-bot-text-color);
   background: var(--chat-bot-bubble-color);
-  border-radius: 14px;
-  padding: 8px 12px;
+  border-radius: var(--chat-bubble-border-radius);
+  padding: var(--chat-bubble-padding);
   opacity: 0.85;
+}
+
+#chat-log a {
+  color: var(--chat-link-color);
+  text-decoration: var(--chat-link-decoration);
+}
+
+#chat-log a:hover {
+  text-decoration: var(--chat-link-decoration-hover);
+}
+
+#chat-log ul {
+  padding-left: 1.2em;
 }
 
 .chat-controls input[type="text"] {
   width: 100%;
-  padding: 8px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  padding: var(--chat-input-padding);
+  border: var(--chat-input-border);
+  border-radius: var(--chat-input-border-radius);
+  font-size: var(--chat-input-font-size);
   box-sizing: border-box;
   margin-bottom: 6px;
+}
+
+.chat-controls input[type="text"]:focus {
+  outline: var(--chat-input-focus-outline);
+  box-shadow: var(--chat-input-focus-shadow);
+  border-color: var(--chat-input-focus-border-color);
 }
 
 .chat-controls .privacy {
@@ -117,6 +236,7 @@ body {
   align-items: center;
   margin-bottom: 6px;
   font-size: 0.9em;
+  color: var(--chat-privacy-color);
 }
 
 .chat-controls .privacy input[type="checkbox"] {
@@ -124,27 +244,29 @@ body {
 }
 
 .chat-controls .privacy a {
-  color: var(--chat-primary-color);
+  color: var(--chat-link-color);
   font-weight: 600;
-  text-decoration: underline;
+  text-decoration: var(--chat-link-decoration);
 }
 
 .chat-controls .privacy a:hover {
-  text-decoration: none;
+  text-decoration: var(--chat-link-decoration-hover);
 }
 
 .chat-controls button {
-  padding: 8px;
-  border: none;
-  border-radius: 4px;
-  background: var(--chat-primary-color);
-  color: var(--chat-primary-text-color);
+  padding: var(--chat-button-padding);
+  border: var(--chat-button-border);
+  border-radius: var(--chat-button-border-radius);
+  background: var(--chat-button-background);
+  color: var(--chat-button-color);
   cursor: pointer;
   font-size: 1em;
+  letter-spacing: var(--chat-button-letter-spacing);
 }
 
 .chat-controls button:disabled {
-  background: #999;
+  background: var(--chat-button-disabled-background);
+  border: var(--chat-button-disabled-border);
   cursor: not-allowed;
 }
 
@@ -152,8 +274,9 @@ body {
   position: fixed;
   bottom: 15px;
   right: 15px;
-  background: rgba(0, 0, 0, 0.6);
-  color: #fff;
+  background: var(--chat-return-link-background);
+  color: var(--chat-return-link-color);
+  border: var(--chat-return-link-border);
   padding: 8px 12px;
   border-radius: 6px;
   text-decoration: none;
@@ -161,7 +284,7 @@ body {
 }
 
 .return-link:hover {
-  background: rgba(0, 0, 0, 0.8);
+  filter: brightness(0.9);
 }
 
 .privacy-box {
@@ -261,8 +384,7 @@ body {
 #chat-log {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 10px;
+  gap: var(--chat-log-gap);
 }
 
 /* Gemeinsame Basis */
@@ -272,10 +394,12 @@ body {
 }
 
 .msg .bubble {
-  max-width: 70%;
-  padding: 8px 12px;
-  border-radius: 12px;
-  line-height: 1.4;
+  max-width: var(--chat-bubble-max-width);
+  padding: var(--chat-bubble-padding);
+  border-radius: var(--chat-bubble-border-radius);
+  line-height: var(--chat-bubble-line-height);
+  font-size: var(--chat-bubble-font-size);
+  letter-spacing: var(--chat-bubble-letter-spacing);
 }
 
 /* Bot (links) */
@@ -286,6 +410,7 @@ body {
   background: var(--chat-bot-bubble-color);
   color: var(--chat-bot-text-color);
   border-top-left-radius: 0;
+  border: var(--chat-bot-bubble-border);
 }
 
 /* User (rechts) */
@@ -296,7 +421,9 @@ body {
   background: var(--chat-user-bubble-color);
   color: var(--chat-user-text-color);
   border-top-right-radius: 0;
-  text-align: right;
+  text-align: var(--chat-user-text-align);
+  letter-spacing: var(--chat-user-letter-spacing);
+  border: var(--chat-user-bubble-border);
 }
 
 

--- a/faehrhaus/assets/css/hotel.css
+++ b/faehrhaus/assets/css/hotel.css
@@ -1,164 +1,98 @@
 /*
  * FÄHRHAUS SYLT – hotelspezifische Stile gemäß CI
- * Farbe: Pantone 432 → #2D393B
- * Typo: Futura (Light/Book/Medium). Falls nicht lizenziert: System-Fallbacks.
  */
 
-/* ====== Typografie ====== */
 @font-face {
-  /* Optional: Wenn ihr eine lizenzierte Futura-Datei hostet, hier einbinden.
-     Andernfalls greifen die Fallbacks. */
   font-family: "FuturaCustom";
   src: url("../fonts/Futura-Book.woff2") format("woff2");
   font-weight: 400;
   font-style: normal;
   font-display: swap;
 }
+
 :root {
-  --fh-ink: #2D393B;            /* Primärschrift-/Linienfarbe */
-  --fh-ink-80: rgba(45,57,59,.8);
-  --fh-ink-20: rgba(45,57,59,.2);
-  --fh-accent: #2D393B;         /* Akzent bleibt tonal */
-  --fh-bg: rgb(45,57,59);             /* grauer Hintergrund */
-  --fh-bubble-user: #2D393B;    /* User-Blase dunkel (negativ, weiße Schrift) */
-  --fh-bubble-bot: #F3F5F5;     /* Sehr helles Grau mit leichter Blaugrün-Note */
-  --fh-focus: #2D393B;
+  --fh-ink: #2d393b;
+  --fh-ink-80: rgba(45, 57, 59, 0.8);
+  --fh-ink-20: rgba(45, 57, 59, 0.2);
+
+  --chat-font-family: "FuturaCustom", "Futura", "Futura PT", "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  --chat-text-color: var(--fh-ink);
+  --chat-background-image: url('../images/background.jpg');
+  --chat-background-attachment: fixed;
+
+  --chat-primary-color: var(--fh-ink);
+  --chat-primary-text-color: #ffffff;
+  --chat-link-color: var(--fh-ink);
+
+  --chat-box-background: rgb(45, 57, 59);
+  --chat-box-border: 1px solid var(--fh-ink-20);
+  --chat-box-border-radius: 14px;
+  --chat-box-shadow: 0 8px 28px rgba(0, 0, 0, 0.12);
+
+  --chat-header-padding: 6px 0 10px;
+  --chat-header-border: 1px solid var(--fh-ink-20);
+  --chat-logo-max-width: 220px;
+  --chat-claim-color: var(--fh-ink-80);
+  --chat-claim-letter-spacing: 0.18em;
+
+  --chat-log-background: #ffffff;
+  --chat-log-border: 1px solid var(--fh-ink-20);
+  --chat-log-border-radius: 10px;
+  --chat-bubble-max-width: 78%;
+  --chat-bubble-padding: 10px 14px;
+  --chat-bubble-border-radius: 14px;
+  --chat-bubble-font-size: 14.5px;
+  --chat-bubble-letter-spacing: 0.02em;
+  --chat-bubble-line-height: 1.5;
+  --chat-bot-bubble-color: #f3f5f5;
+  --chat-bot-bubble-border: 1px solid var(--fh-ink-20);
+  --chat-user-bubble-color: var(--fh-ink);
+  --chat-user-text-color: #ffffff;
+  --chat-user-letter-spacing: 0.03em;
+  --chat-user-bubble-border: 1px solid var(--fh-ink);
+
+  --chat-input-border: 1px solid var(--fh-ink-20);
+  --chat-input-border-radius: 10px;
+  --chat-input-padding: 12px 14px;
+  --chat-input-font-size: 15px;
+  --chat-input-focus-shadow: 0 0 0 3px color-mix(in srgb, var(--fh-ink) 30%, transparent);
+  --chat-input-focus-border-color: var(--fh-ink);
+
+  --chat-privacy-color: #ffffff;
+
+  --chat-button-background: #ffffff;
+  --chat-button-color: var(--fh-ink);
+  --chat-button-border: 1px solid transparent;
+  --chat-button-border-radius: 10px;
+  --chat-button-padding: 10px 14px;
+  --chat-button-letter-spacing: 0.06em;
+  --chat-button-disabled-background: #9aa3a5;
+  --chat-button-disabled-border: 1px solid #9aa3a5;
+
+  --chat-return-link-background: rgba(45, 57, 59, 0.85);
+  --chat-return-link-border: 1px solid var(--fh-ink);
 }
 
-html, body {
-  font-family: "FuturaCustom", "Futura", "Futura PT", "Avenir Next", "Helvetica Neue", Arial, sans-serif;
-  color: var(--fh-ink);
-  background: url('../images/background.jpg') no-repeat center center fixed !important;
-  background-size: cover !important;
+h1,
+h2,
+h3 {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-weight: 500;
 }
 
-/* Grundlayout (Core überschreiben) */
-.chat-box {
-  background: var(--fh-bg);
-  border-radius: 14px;
-  box-shadow: 0 8px 28px rgba(0,0,0,.12);
-  border: 1px solid var(--fh-ink-20);
-}
-
-/* Header mit Logo + optionalem Claim */
-.chat-box header {
-  padding: 6px 0 10px;
-  border-bottom: 1px solid var(--fh-ink-20);
-  margin-bottom: 10px;
-}
-.chat-box header img {
-  max-width: 220px;
-  height: auto;
-  display: block;
-  margin: 0 auto 6px auto;
-  filter: none; /* Logo unverfälscht anzeigen */
-}
-.brand-claim {
-  font-size: 10px;
-  letter-spacing: .18em;      /* Headlines 100–200 → 0.10–0.20em */
-  text-align: center;
-  color: var(--fh-ink-80);
-  margin-top: 2px;
-}
-
-/* Chatbereich */
-#chat-log {
-  background: #fff;
-  border: 1px solid var(--fh-ink-20);
-  border-radius: 10px;
-}
-
-/* Bubbles – links (Bot) / rechts (User) im Messenger-Stil */
-.msg { display: flex; width: 100%; }
-.msg .bubble {
-  max-width: 78%;
-  padding: 10px 14px;
-  border-radius: 14px;
-  line-height: 1.5;
-  font-size: 14.5px;           /* Fließtext ~12pt → ca. 16px; hier minimal kleiner, wirkt eleganter */
-  letter-spacing: .02em;       /* Fließtext Laufweite ~50 → ~0.05em; wir gehen moderat */
-}
-
-/* Bot (links, positiv) */
-.msg.bot { justify-content: flex-start; }
-.msg.bot .bubble {
-  background: var(--fh-bubble-bot);
-  color: var(--fh-ink);
-  border-top-left-radius: 4px;
-  border: 1px solid var(--fh-ink-20);
-}
-
-/* User (rechts, negativ) */
-.msg.user { justify-content: flex-end; }
-.msg.user .bubble {
-  background: var(--fh-bubble-user);
-  color: #fff;
-  border-top-right-radius: 4px;
-  letter-spacing: .03em;       /* etwas mehr Tracking für Negativschrift */
-  text-align: right;
-  border: 1px solid var(--fh-ink);
-}
-
-/* Labels „Max:“ / „Du:“ zurückhaltend (Book/Medium) */
-.msg .bubble strong {
-  letter-spacing: .05em;
-  font-weight: 500;            /* Medium */
-  display: inline-block;
-  margin-right: .35em;
-  opacity: .9;
-}
-
-/* Eingabe + Buttons */
-.chat-controls input[type="text"] {
-  border: 1px solid var(--fh-ink-20);
-  border-radius: 10px;
-  padding: 12px 14px;
-  font-size: 15px;
-  letter-spacing: .02em;
-}
-.chat-controls input[type="text"]:focus {
-  outline: 2px solid transparent;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--fh-focus) 30%, transparent);
-  border-color: var(--fh-focus);
-}
-.chat-controls .privacy {
-  color: white;
-}
-.chat-controls button {
-  background: #fff;
-  color: var(--fh-ink);
-  border-radius: 10px;
-  padding: 10px 14px;
-  letter-spacing: .06em;       /* leichter „Button“-Look */
-}
-.chat-controls button:disabled {
-  background: #9AA3A5;
-}
-
-/* Sekundäre Elemente */
-.return-link {
-  background: rgba(45,57,59, .85);
-  border: 1px solid var(--fh-ink);
-}
-
-/* Kleintypografie im Log (Links, Listen) */
 #chat-log a {
-  color: var(--fh-ink);
   text-decoration-thickness: 1px;
 }
-#chat-log ul { padding-left: 1.2em; }
 
-/* Headline-Typo – falls irgendwo Überschriften auftauchen */
-h1, h2, h3 {
-  text-transform: uppercase; 
-  letter-spacing: .14em;      /* 100–200 → 0.10–0.20em, mittig gewählt */
-  font-weight: 500;           /* Book/Medium */
+.brand-claim {
+  text-align: center;
 }
 
 .privacy-box .privacy-content h1 {
   margin: 0 0 16px;
   font-size: 26px;
-  color: #fff;
+  color: #ffffff;
 }
 
 .privacy-box .privacy-content h2 {

--- a/roth/assets/css/hotel.css
+++ b/roth/assets/css/hotel.css
@@ -1,140 +1,78 @@
-:root{
-  --ah-ink: #000;           /* dunkles Blaugrün für Texte, Linien */
-  --ah-ink-80: #ae2a23ce;
-  --ah-ink-20: #ae2a234a;
-  --ah-brand: #ae2b23;         /* Hotel Roth Akzent/Brand (Teal) */
-  --ah-bg: #FFFFFF;            /* Grundfläche */
-  --ah-bubble-user: #ae2b23;   /* User-Bubble (negativ/weiß) */
-  --ah-bubble-bot: #F1F6F7;    /* sehr hell, leicht bläulich */
-  --ah-header: #ae2b23;        /* sehr dunkler Header für weißes Logo */
-  --ah-focus: #ae2b23;
+/*
+ * HOTEL ROTH – individuelle Farben und Typografie
+ */
+
+:root {
+  --roth-ink: #000000;
+  --roth-ink-80: rgba(174, 42, 35, 0.81);
+  --roth-ink-20: rgba(174, 42, 35, 0.29);
+  --roth-brand: #ae2b23;
+
+  --chat-font-family: "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  --chat-text-color: var(--roth-ink);
+  --chat-background-image: url('../images/background.jpg');
+  --chat-background-attachment: fixed;
+
+  --chat-primary-color: var(--roth-brand);
+  --chat-primary-text-color: #ffffff;
+  --chat-link-color: var(--roth-brand);
+
+  --chat-box-background: #ffffff;
+  --chat-box-border: 1px solid var(--roth-ink-20);
+  --chat-box-border-radius: 14px;
+  --chat-box-shadow: 0 8px 28px rgba(0, 0, 0, 0.1);
+  --chat-box-overflow: hidden;
+
+  --chat-header-background: var(--roth-brand);
+  --chat-header-padding: 14px 0 12px;
+  --chat-header-border: 1px solid rgba(255, 255, 255, 0.12);
+  --chat-logo-max-width: 210px;
+  --chat-claim-color: rgba(255, 255, 255, 0.9);
+
+  --chat-log-border: 1px solid var(--roth-ink-20);
+  --chat-log-border-radius: 10px;
+  --chat-log-gap: 8px;
+
+  --chat-bubble-max-width: 78%;
+  --chat-bubble-padding: 10px 14px;
+  --chat-bubble-border-radius: 14px;
+  --chat-bubble-letter-spacing: 0.01em;
+  --chat-bubble-line-height: 1.5;
+  --chat-bot-bubble-color: #f1f6f7;
+  --chat-bot-text-color: var(--roth-ink);
+  --chat-bot-bubble-border: 1px solid var(--roth-ink-20);
+  --chat-user-bubble-color: var(--roth-brand);
+  --chat-user-text-color: #ffffff;
+  --chat-user-bubble-border: 1px solid color-mix(in srgb, var(--roth-brand) 70%, #000 30%);
+
+  --chat-input-border: 1px solid var(--roth-ink-20);
+  --chat-input-border-radius: 10px;
+  --chat-input-padding: 12px 14px;
+  --chat-input-font-size: 15px;
+  --chat-input-focus-shadow: 0 0 0 3px color-mix(in srgb, var(--roth-brand) 25%, transparent);
+  --chat-input-focus-border-color: var(--roth-brand);
+
+  --chat-privacy-color: var(--roth-ink-80);
+
+  --chat-button-background: var(--roth-brand);
+  --chat-button-border: 1px solid color-mix(in srgb, var(--roth-brand) 70%, #000 30%);
+  --chat-button-border-radius: 10px;
+  --chat-button-padding: 10px 14px;
+  --chat-button-letter-spacing: 0.03em;
+  --chat-button-disabled-background: #c78f89;
+  --chat-button-disabled-border: 1px solid #c78f89;
+
+  --chat-return-link-background: rgba(174, 43, 35, 0.9);
+  --chat-return-link-border: 1px solid color-mix(in srgb, var(--roth-brand) 70%, #000 30%);
 }
 
-/* Typo: eleganter Sans-Serif-Fallback; wenn ihr Branding-Fonts habt, hier einbinden */
-html, body{
-  font-family: "Avenir Next","Helvetica Neue",Arial,sans-serif;
-  color: var(--ah-ink);
-  background: url('../images/background.jpg') no-repeat center center fixed!important;
-  background-size: cover !important;
-}
-
-
-
-/* Chat-Container */
-.chat-box{
-  background: #fff;
-  border-radius: 14px;
-  box-shadow: 0 8px 28px rgba(0,0,0,.10);
-  border: 1px solid var(--ah-ink-20);
-  overflow: hidden; /* damit Header oben bündig ist */
-}
-
-/* Header mit dunklem Balken für weißes Logo */
-.chat-box header{
-  background: var(--ah-header);
-  padding: 14px 0 12px;
-  border-bottom: 1px solid rgba(255,255,255,.12);
-  margin-bottom: 10px;
-  text-align: center;
-}
-.chat-box header img{
-  max-width: 210px;
-  height: auto;
-  display: inline-block;
-  filter: none; /* weißes Logo unverändert */
-}
-
-/* Optionaler Claim unter dem Logo (falls gewünscht) */
-.brand-claim{
-  color: rgba(255,255,255,.9);
-  font-size: 11px;
-  letter-spacing: .12em;
-  text-transform: uppercase;
-  margin-top: 4px;
-}
-
-/* Chatbereich */
-#chat-log{
-  background: #fff;
-  border: 1px solid var(--ah-ink-20);
-  border-radius: 10px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px;
-}
-
-/* Bubbles – Bot links, User rechts */
-.msg{ display:flex; width:100%; }
-.msg .bubble{
-  max-width: 78%;
-  padding: 10px 14px;
-  border-radius: 14px;
-  line-height: 1.5;
-  font-size: 15px;
-  letter-spacing: .01em;
-}
-
-/* Bot (links, positiv) */
-.msg.bot{ justify-content:flex-start; }
-.msg.bot .bubble{
-  background: var(--ah-bubble-bot);
-  color: var(--ah-ink);
-  border-top-left-radius: 4px;
-  border: 1px solid var(--ah-ink-20);
-}
-
-/* User (rechts, negativ/weiß) */
-.msg.user{ justify-content:flex-end; }
-.msg.user .bubble{
-  background: var(--ah-bubble-user);
-  color: #fff;
-  border-top-right-radius: 4px;
-  border: 1px solid color-mix(in srgb, var(--ah-bubble-user) 70%, #000 30%);
-  text-align: right;
-}
-
-/* Labels „Max:“ / „Du:“ zurückhaltend */
-.msg .bubble strong{
+.msg .bubble strong {
   font-weight: 600;
-  letter-spacing: .04em;
-  opacity: .95;
-  margin-right: .35em;
+  letter-spacing: 0.04em;
+  opacity: 0.95;
+  margin-right: 0.35em;
 }
 
-/* Eingabe & Buttons */
-.chat-controls input[type="text"]{
-  border: 1px solid var(--ah-ink-20);
-  border-radius: 10px;
-  padding: 12px 14px;
-  font-size: 15px;
+#chat-log a {
+  text-decoration-thickness: 1px;
 }
-.chat-controls input[type="text"]:focus{
-  outline: 2px solid transparent;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ah-focus) 25%, transparent);
-  border-color: var(--ah-focus);
-}
-.chat-controls .privacy{ color: var(--ah-ink-80); }
-.chat-controls button{
-  background: var(--ah-brand);
-  color: #fff;
-  border-radius: 10px;
-  padding: 10px 14px;
-  letter-spacing: .03em;
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
-}
-.chat-controls button:disabled{
-  background: #9FB8C1;
-  border-color: #9FB8C1;
-}
-
-/* „Zurück zur Website“-Button */
-.return-link{
-  background: rgba(15,110,143,.9);
-  border: 1px solid color-mix(in srgb, var(--ah-brand) 70%, #000 30%);
-  color: #fff;
-}
-
-/* Links im Chat */
-#chat-log a{ color: var(--ah-brand); text-decoration-thickness: 1px; }
-#chat-log ul{ padding-left: 1.2em; }


### PR DESCRIPTION
## Summary
- expose comprehensive theme variables in `core/assets/css/style.css` and update core chat layout styles to consume them
- reduce each hotel stylesheet to hotel-specific variable assignments with minimal custom tweaks

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d432ed0af8832495ef566098e2188d