### PR TITLE
Handle hotel-relative absolute asset paths

### DIFF
--- a/core/init.php
+++ b/core/init.php
@@ -106,6 +106,22 @@ if (!function_exists('chatbot_asset_url')) {
         }
 
         if ($value[0] === '/') {
+            if ($hotelBasePath) {
+                $baseReal = realpath($hotelBasePath) ?: $hotelBasePath;
+                $normalizedBase = str_replace('\\', '/', rtrim($baseReal, '/\\')) . '/';
+
+                $valueReal = realpath($value);
+                $normalizedAbsolute = $valueReal !== false
+                    ? str_replace('\\', '/', $valueReal)
+                    : str_replace('\\', '/', $value);
+
+                if (strpos($normalizedAbsolute, $normalizedBase) === 0) {
+                    $relative = substr($normalizedAbsolute, strlen($normalizedBase));
+                    $relative = ltrim($relative, '/');
+                    return $relative === '' ? basename($normalizedAbsolute) : $relative;
+                }
+            }
+
             return $value;
         }
 


### PR DESCRIPTION
## Summary
- ensure `chatbot_asset_url()` rewrites absolute asset paths within the hotel directory to relative web paths

## Testing
- php -l core/init.php

------
https://chatgpt.com/codex/tasks/task_e_68d44a0b0c288324929dc2976e4d26ea