### PR TITLE
Refactor theme color settings to new token model

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ manually when automating deployments. The most commonly adjusted keys are:
 - **Branding assets:** `$LOGO_PATH`, `$BACKGROUND_IMAGE_URL`, and `$HOTEL_CSS_URL`
   control the header logo, optional background image, and additional CSS loaded into
   the chat shell. `$BOT_NAME` sets the label shown for bot messages.【F:core/config.sample.php†L8-L28】【F:core/index.php†L16-L47】
-- **Color palette:** `$CHAT_BACKGROUND_COLOR`, `$CHAT_BOX_BACKGROUND_COLOR`,
-  `$CHAT_PRIMARY_COLOR`, `$CHAT_PRIMARY_TEXT_COLOR`, `$CHAT_USER_BUBBLE_COLOR`,
-  `$CHAT_USER_TEXT_COLOR`, `$CHAT_BOT_BUBBLE_COLOR`, `$CHAT_BOT_TEXT_COLOR`, and
-  `$CHAT_LINK_COLOR` map directly to CSS custom properties that define the chat UI
-  colors.【F:core/config.sample.php†L20-L35】【F:core/admin.php†L92-L113】
+- **Color palette:** `THEME_COLOR_BASE`, `THEME_COLOR_SURFACE`,
+  `THEME_COLOR_PRIMARY`, `THEME_COLOR_PRIMARY_CONTRAST`, and
+  `THEME_COLOR_TEXT` feed the core design tokens that all other chat colors are
+  derived from.【F:core/config.sample.php†L20-L40】【F:core/admin.php†L92-L140】
+  Legacy `CHAT_*` keys remain supported for older hotel configs but are no
+  longer surfaced in the admin UI.【F:core/config.sample.php†L32-L40】【F:core/admin.php†L128-L140】
 
 Changes made via the admin UI are persisted in `config.php`; editing the file by hand
 is useful when seeding defaults before handing access to hotel operators.

--- a/core/config.sample.php
+++ b/core/config.sample.php
@@ -20,16 +20,24 @@ $HOTEL_CSS_URL = 'assets/css/hotel.css';
 // Optional: Bild für den Seitenhintergrund. Relativ zum Hotelordner oder als URL.
 $BACKGROUND_IMAGE_URL = '';
 
-// Farbwerte für das Standard-Layout. Sie können hier oder im Admin-Bereich angepasst werden.
-$CHAT_BACKGROUND_COLOR      = '#f0f0f0';
-$CHAT_BOX_BACKGROUND_COLOR  = '#808080';
-$CHAT_PRIMARY_COLOR         = '#003366';
-$CHAT_PRIMARY_TEXT_COLOR    = '#ffffff';
-$CHAT_USER_BUBBLE_COLOR     = '#0078d7';
-$CHAT_USER_TEXT_COLOR       = '#ffffff';
-$CHAT_BOT_BUBBLE_COLOR      = '#f0f0f0';
-$CHAT_BOT_TEXT_COLOR        = '#000000';
-$CHAT_LINK_COLOR            = '#003366';
+// Farbwerte für das Standard-Layout. Alle abgeleiteten Farben orientieren sich an diesen fünf Tokens.
+$THEME_COLOR_BASE = '#F0F0F0';
+$THEME_COLOR_SURFACE = '#FFFFFF';
+$THEME_COLOR_PRIMARY = '#003366';
+$THEME_COLOR_PRIMARY_CONTRAST = '#FFFFFF';
+$THEME_COLOR_TEXT = '#0F172A';
+
+// Legacy: Ältere Installationen nutzten detaillierte CHAT_* Konstanten.
+// Diese werden automatisch auf die THEME_COLOR_* Werte abgebildet, können aber entfernt werden.
+// $CHAT_BACKGROUND_COLOR      = '#f0f0f0';
+// $CHAT_BOX_BACKGROUND_COLOR  = '#808080';
+// $CHAT_PRIMARY_COLOR         = '#003366';
+// $CHAT_PRIMARY_TEXT_COLOR    = '#ffffff';
+// $CHAT_USER_BUBBLE_COLOR     = '#0078d7';
+// $CHAT_USER_TEXT_COLOR       = '#ffffff';
+// $CHAT_BOT_BUBBLE_COLOR      = '#f0f0f0';
+// $CHAT_BOT_TEXT_COLOR        = '#000000';
+// $CHAT_LINK_COLOR            = '#003366';
 
 // Pfad zur FAQ‑Markdown‑Datei, die die Wissensbasis für das Hotel enthält.
 $FAQ_FILE = __DIR__ . '/data/faq.md';

--- a/core/partials/style_overrides.php
+++ b/core/partials/style_overrides.php
@@ -4,21 +4,34 @@
  */
 $styleVariables = [];
 $colorMap = [
-    'CHAT_BACKGROUND_COLOR'     => '--chat-background-color',
-    'CHAT_BOX_BACKGROUND_COLOR' => '--chat-box-background-color',
-    'CHAT_PRIMARY_COLOR'        => '--chat-primary-color',
-    'CHAT_PRIMARY_TEXT_COLOR'   => '--chat-primary-text-color',
-    'CHAT_USER_BUBBLE_COLOR'    => '--chat-user-bubble-color',
-    'CHAT_USER_TEXT_COLOR'      => '--chat-user-text-color',
-    'CHAT_BOT_BUBBLE_COLOR'     => '--chat-bot-bubble-color',
-    'CHAT_BOT_TEXT_COLOR'       => '--chat-bot-text-color',
-    'CHAT_LINK_COLOR'           => '--chat-link-color',
+    'THEME_COLOR_BASE'             => '--theme-color-base',
+    'THEME_COLOR_SURFACE'          => '--theme-color-surface',
+    'THEME_COLOR_PRIMARY'          => '--theme-color-primary',
+    'THEME_COLOR_PRIMARY_CONTRAST' => '--theme-color-primary-contrast',
+    'THEME_COLOR_TEXT'             => '--theme-color-text',
+];
+
+$themeDefaults = [
+    'THEME_COLOR_BASE'             => '#F0F0F0',
+    'THEME_COLOR_SURFACE'          => '#FFFFFF',
+    'THEME_COLOR_PRIMARY'          => '#003366',
+    'THEME_COLOR_PRIMARY_CONTRAST' => '#FFFFFF',
+    'THEME_COLOR_TEXT'             => '#0F172A',
 ];
 
 foreach ($colorMap as $configKey => $cssVar) {
-    if (isset($$configKey) && is_string($$configKey) && $$configKey !== '') {
-        $styleVariables[] = $cssVar . ': ' . htmlspecialchars((string)$$configKey, ENT_QUOTES);
+    $value = isset($$configKey) ? chatbot_normalize_hex_color((string)$$configKey) : null;
+
+    if ($value === null) {
+        continue;
     }
+
+    $default = $themeDefaults[$configKey] ?? null;
+    if ($default !== null && $value === $default) {
+        continue;
+    }
+
+    $styleVariables[] = $cssVar . ': ' . htmlspecialchars($value, ENT_QUOTES);
 }
 
 $backgroundImageUrl = null;


### PR DESCRIPTION
## Summary
- replace the admin color settings with THEME_COLOR_* tokens, including normalization and legacy CHAT_* fallbacks
- ensure init/style overrides derive CSS variables from the new theme tokens so existing hotels keep their branding
- document the new theme constants in the sample config and README while marking the old keys as legacy

## Testing
- php -l core/init.php
- php -l core/admin.php
- php -l core/partials/style_overrides.php

------
https://chatgpt.com/codex/tasks/task_e_68d44cebf7dc8324ab5f6897f489c12a