### PR TITLE
Refactor style overrides to use theme tokens

### DIFF
--- a/core/index.php
+++ b/core/index.php
@@ -35,10 +35,12 @@ $logoSrc = chatbot_asset_url($LOGO_PATH ?? null, $HOTEL_BASE_PATH ?? null);
     // wird sie hier eingebunden. Dadurch lassen sich Farben und Layout einfach je
     // Standort anpassen, ohne den Core zu verändern.
     if (isset($hotelCssUrl) && $hotelCssUrl) {
-        echo '<link rel="stylesheet" href="' . htmlspecialchars($hotelCssUrl) . '">';
+        ?>
+    <link rel="stylesheet" href="<?php echo htmlspecialchars($hotelCssUrl); ?>">
+    <?php
     }
-    include __DIR__ . '/partials/style_overrides.php';
     ?>
+    <?php include __DIR__ . '/partials/style_overrides.php'; ?>
 </head>
 <body>
     <div class="chat-overlay">

--- a/core/partials/style_overrides.php
+++ b/core/partials/style_overrides.php
@@ -3,13 +3,6 @@
  * Gibt dynamische Style-Overrides aus, die über die Konfiguration gesetzt werden können.
  */
 $styleVariables = [];
-$colorMap = [
-    'THEME_COLOR_BASE'             => '--theme-color-base',
-    'THEME_COLOR_SURFACE'          => '--theme-color-surface',
-    'THEME_COLOR_PRIMARY'          => '--theme-color-primary',
-    'THEME_COLOR_PRIMARY_CONTRAST' => '--theme-color-primary-contrast',
-    'THEME_COLOR_TEXT'             => '--theme-color-text',
-];
 
 $themeDefaults = [
     'THEME_COLOR_BASE'             => '#F0F0F0',
@@ -19,19 +12,34 @@ $themeDefaults = [
     'THEME_COLOR_TEXT'             => '#0F172A',
 ];
 
-foreach ($colorMap as $configKey => $cssVar) {
-    $value = isset($$configKey) ? chatbot_normalize_hex_color((string)$$configKey) : null;
+$legacyTranslations = [
+    'THEME_COLOR_BASE'             => $CHAT_BACKGROUND_COLOR ?? null,
+    'THEME_COLOR_SURFACE'          => $CHAT_BOX_BACKGROUND_COLOR ?? null,
+    'THEME_COLOR_PRIMARY'          => $CHAT_PRIMARY_COLOR ?? null,
+    'THEME_COLOR_PRIMARY_CONTRAST' => $CHAT_PRIMARY_TEXT_COLOR ?? null,
+    'THEME_COLOR_TEXT'             => $CHAT_BOT_TEXT_COLOR ?? null,
+];
+
+foreach ($themeDefaults as $themeKey => $defaultHex) {
+    $value = isset(${$themeKey}) ? chatbot_normalize_hex_color((string)${$themeKey}) : null;
 
     if ($value === null) {
+        $legacy = $legacyTranslations[$themeKey] ?? null;
+        if (is_string($legacy)) {
+            $value = chatbot_normalize_hex_color($legacy);
+        }
+    }
+
+    if ($value === null || $value === $defaultHex) {
         continue;
     }
 
-    $default = $themeDefaults[$configKey] ?? null;
-    if ($default !== null && $value === $default) {
-        continue;
-    }
+    $cssVariable = '--' . strtolower(strtr($themeKey, [
+        'THEME_' => 'theme-',
+        '_'      => '-',
+    ]));
 
-    $styleVariables[] = $cssVar . ': ' . htmlspecialchars($value, ENT_QUOTES);
+    $styleVariables[] = $cssVariable . ': ' . htmlspecialchars($value, ENT_QUOTES);
 }
 
 $backgroundImageUrl = null;

--- a/core/privacy.php
+++ b/core/privacy.php
@@ -26,10 +26,12 @@ $chatReturnUrl = $chatReturnUrl ?? 'index.php';
     <link rel="stylesheet" href="<?php echo htmlspecialchars($coreRelative); ?>/assets/css/style.css">
     <?php
     if (isset($hotelCssUrl) && $hotelCssUrl) {
-        echo '<link rel="stylesheet" href="' . htmlspecialchars($hotelCssUrl) . '">';
+        ?>
+    <link rel="stylesheet" href="<?php echo htmlspecialchars($hotelCssUrl); ?>">
+    <?php
     }
-    include __DIR__ . '/partials/style_overrides.php';
     ?>
+    <?php include __DIR__ . '/partials/style_overrides.php'; ?>
 </head>
 <body class="privacy-page">
     <div class="chat-overlay">


### PR DESCRIPTION
## Summary
- refactor the style overrides partial to emit --theme-color-* variables based on THEME_COLOR_* values and fallback CHAT_* legacy keys
- ensure inline style block renders after external hotel stylesheets in index and privacy templates

## Testing
- php -l core/partials/style_overrides.php
- php -l core/index.php
- php -l core/privacy.php
- php -r '$configPath="core/config.sample.php"; require "core/init.php"; ob_start(); include "core/partials/style_overrides.php"; $out = ob_get_clean(); echo strlen($out) === 0 ? "(no output)\n" : $out;'
- php -r '$configPath="core/config.sample.php"; require "core/init.php"; $THEME_COLOR_PRIMARY = "#112233"; ob_start(); include "core/partials/style_overrides.php"; echo ob_get_clean();'
- php -r '$configPath="core/config.sample.php"; require "core/init.php"; unset($THEME_COLOR_PRIMARY); $CHAT_PRIMARY_COLOR = "#445566"; ob_start(); include "core/partials/style_overrides.php"; echo ob_get_clean();'
- php -r '$configPath="core/config.sample.php"; require "core/init.php"; $BACKGROUND_IMAGE_URL = "https://example.com/bg.jpg"; ob_start(); include "core/partials/style_overrides.php"; echo ob_get_clean();'

------
https://chatgpt.com/codex/tasks/task_e_68d44fcaf69083249b0d1ce37be7b622