### PR TITLE
Add conversation history handling across chat and admin

### DIFF
--- a/api/config.php
+++ b/api/config.php
@@ -10,3 +10,4 @@ $ALLOWED_ORIGIN = 'https://chatbot.syltwerk.de'; // CORS: allow same origin
 // Safety: hard-limit max prompt size
 $MAX_CONTEXT_CHARS = 12000;
 $MAX_QUESTION_CHARS = 2000;
+$MAX_HISTORY_DEPTH = (int) (getenv('MAX_HISTORY_DEPTH') ?: 20);

--- a/core/analytics_helpers.php
+++ b/core/analytics_helpers.php
@@ -108,7 +108,7 @@ function analytics_fetch_data(?PDO $db, array $filters): array
         $stats = $stmtTop->fetchAll(PDO::FETCH_ASSOC) ?: [];
 
         // Letzte Einträge
-        $sqlLast = "SELECT question, answer, time
+        $sqlLast = "SELECT question, answer, time, conversation_id, history
                     FROM logs
                     $whereSql
                     ORDER BY time DESC
@@ -203,9 +203,9 @@ function analytics_export_csv(?PDO $db, array $filters): void
     if ($out === false) {
         exit;
     }
-    fputcsv($out, ['time', 'question', 'answer']);
+    fputcsv($out, ['time', 'question', 'answer', 'conversation_id', 'history']);
 
-    $sql = "SELECT time, question, answer
+    $sql = "SELECT time, question, answer, conversation_id, history
             FROM logs
             $whereSql
             ORDER BY time DESC
@@ -214,7 +214,13 @@ function analytics_export_csv(?PDO $db, array $filters): void
     foreach ($params as $k => $v) { $stmt->bindValue($k, $v); }
     $stmt->execute();
     while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-        fputcsv($out, [$row['time'], $row['question'], $row['answer']]);
+        fputcsv($out, [
+            $row['time'],
+            $row['question'],
+            $row['answer'],
+            $row['conversation_id'] ?? '',
+            $row['history'] ?? '',
+        ]);
     }
     fclose($out);
     exit;

--- a/core/init.php
+++ b/core/init.php
@@ -131,8 +131,20 @@ if (isset($LOG_DB) && is_string($LOG_DB)) {
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             question TEXT NOT NULL,
             answer TEXT NOT NULL,
+            conversation_id TEXT,
+            history TEXT,
             time DATETIME DEFAULT CURRENT_TIMESTAMP
         )');
+        try {
+            $db->exec('ALTER TABLE logs ADD COLUMN conversation_id TEXT');
+        } catch (Exception $e) {
+            // Spalte existiert bereits
+        }
+        try {
+            $db->exec('ALTER TABLE logs ADD COLUMN history TEXT');
+        } catch (Exception $e) {
+            // Spalte existiert bereits
+        }
     } catch (Exception $e) {
         // Bei Fehlern die Verbindung null setzen
         $db = null;

--- a/core/partials/analysis_content.php
+++ b/core/partials/analysis_content.php
@@ -153,13 +153,48 @@
       <h2>Letzte Anfragen</h2>
       <div class="table-scroll">
         <table>
-          <thead><tr><th>Zeit</th><th>Frage</th><th>Antwort</th></tr></thead>
+          <thead><tr><th>Zeit</th><th>Konversation</th><th>Frage</th><th>Antwort</th><th>Verlauf</th></tr></thead>
           <tbody>
             <?php foreach ($analysisData['logs'] as $row): ?>
+              <?php
+                $historyPretty = '';
+                if (!empty($row['history'])) {
+                    $decodedHistory = json_decode((string)$row['history'], true);
+                    if (is_array($decodedHistory)) {
+                        $parts = [];
+                        foreach ($decodedHistory as $item) {
+                            if (!is_array($item)) {
+                                continue;
+                            }
+                            $role = isset($item['role']) ? (string)$item['role'] : '';
+                            $content = isset($item['content']) ? (string)$item['content'] : '';
+                            if ($content === '') {
+                                continue;
+                            }
+                            $label = $role !== '' ? ucfirst($role) : 'Unbekannt';
+                            $parts[] = $label . ': ' . $content;
+                        }
+                        if ($parts) {
+                            $historyPretty = implode("\n\n", $parts);
+                        }
+                    }
+                }
+              ?>
               <tr>
                 <td><?php echo htmlspecialchars($row['time']); ?></td>
+                <td><?php echo htmlspecialchars($row['conversation_id'] ?? ''); ?></td>
                 <td><?php echo htmlspecialchars($row['question']); ?></td>
                 <td><?php echo nl2br(htmlspecialchars($row['answer'])); ?></td>
+                <td>
+                  <?php if ($historyPretty !== ''): ?>
+                    <details>
+                      <summary>anzeigen</summary>
+                      <pre><?php echo htmlspecialchars($historyPretty); ?></pre>
+                    </details>
+                  <?php else: ?>
+                    <span class="muted">–</span>
+                  <?php endif; ?>
+                </td>
               </tr>
             <?php endforeach; ?>
           </tbody>


### PR DESCRIPTION
## Summary
- persist chat history on the frontend and send conversation identifiers with each request
- validate and forward history in core/chat.php, logging full transcripts with conversation IDs
- adapt the OpenAI proxy to accept message histories with a configurable depth and surface history in admin analytics and exports

## Testing
- php -l core/chat.php
- php -l core/init.php
- php -l api/ask.php
- php -l core/analytics_helpers.php
- php -l core/partials/analysis_content.php
- php -l api/config.php

------
https://chatgpt.com/codex/tasks/task_e_68d525d1c148832494a5722ded91e363