### PR TITLE
Remove support for legacy chat color config keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ manually when automating deployments. The most commonly adjusted keys are:
   `THEME_COLOR_PRIMARY`, `THEME_COLOR_PRIMARY_CONTRAST`, and
   `THEME_COLOR_TEXT` feed the core design tokens that all other chat colors are
   derived from.【F:core/config.sample.php†L20-L40】【F:core/admin.php†L92-L140】
-  Legacy `CHAT_*` keys remain supported for older hotel configs but are no
-  longer surfaced in the admin UI.【F:core/config.sample.php†L32-L40】【F:core/admin.php†L128-L140】
 
 Changes made via the admin UI are persisted in `config.php`; editing the file by hand
 is useful when seeding defaults before handing access to hotel operators.

--- a/core/admin.php
+++ b/core/admin.php
@@ -412,23 +412,17 @@ function admin_load_theme_colors_from_css(?string $cssUrl, ?string $hotelBasePat
 }
 
 /**
- * Ermittelt den anzuzeigenden Theme-Farbwert anhand neuer und alter Konfigurationsschlüssel.
+ * Ermittelt den anzuzeigenden Theme-Farbwert anhand der aktuellen Konfigurationsschlüssel.
  *
  * @param mixed $primaryValue
- * @param mixed $legacyValue
  * @param string $default
  * @param string|null $cssFallback
  */
-function admin_resolve_theme_color($primaryValue, $legacyValue, string $default, ?string $cssFallback = null): string
+function admin_resolve_theme_color($primaryValue, string $default, ?string $cssFallback = null): string
 {
     $normalizedPrimary = admin_normalize_hex_color(is_string($primaryValue) ? $primaryValue : null);
     if ($normalizedPrimary !== null) {
         return $normalizedPrimary;
-    }
-
-    $normalizedLegacy = admin_normalize_hex_color(is_string($legacyValue) ? $legacyValue : null);
-    if ($normalizedLegacy !== null) {
-        return $normalizedLegacy;
     }
 
     $normalizedCss = admin_normalize_hex_color($cssFallback);
@@ -496,19 +490,10 @@ $themeDefaults = [
     'THEME_COLOR_TEXT'             => '#0F172A',
 ];
 
-$legacyThemeValues = [
-    'THEME_COLOR_BASE'             => isset($CHAT_BACKGROUND_COLOR) ? (string)$CHAT_BACKGROUND_COLOR : null,
-    'THEME_COLOR_SURFACE'          => isset($CHAT_BOX_BACKGROUND_COLOR) ? (string)$CHAT_BOX_BACKGROUND_COLOR : null,
-    'THEME_COLOR_PRIMARY'          => isset($CHAT_PRIMARY_COLOR) ? (string)$CHAT_PRIMARY_COLOR : null,
-    'THEME_COLOR_PRIMARY_CONTRAST' => isset($CHAT_PRIMARY_TEXT_COLOR) ? (string)$CHAT_PRIMARY_TEXT_COLOR : null,
-    'THEME_COLOR_TEXT'             => isset($CHAT_BOT_TEXT_COLOR) ? (string)$CHAT_BOT_TEXT_COLOR : null,
-];
-
 foreach ($themeDefaults as $themeKey => $defaultValue) {
     $primaryValue = isset(${$themeKey}) ? (string)${$themeKey} : null;
-    $legacyValue = $legacyThemeValues[$themeKey] ?? null;
     $cssFallback = $cssThemeColors[$themeKey] ?? null;
-    $settingsValues[$themeKey] = admin_resolve_theme_color($primaryValue, $legacyValue, $defaultValue, $cssFallback);
+    $settingsValues[$themeKey] = admin_resolve_theme_color($primaryValue, $defaultValue, $cssFallback);
     ${$themeKey} = $settingsValues[$themeKey];
 }
 

--- a/core/config.sample.php
+++ b/core/config.sample.php
@@ -27,18 +27,6 @@ $THEME_COLOR_PRIMARY = '#003366';
 $THEME_COLOR_PRIMARY_CONTRAST = '#FFFFFF';
 $THEME_COLOR_TEXT = '#0F172A';
 
-// Legacy: Ältere Installationen nutzten detaillierte CHAT_* Konstanten.
-// Diese werden automatisch auf die THEME_COLOR_* Werte abgebildet, können aber entfernt werden.
-// $CHAT_BACKGROUND_COLOR      = '#f0f0f0';
-// $CHAT_BOX_BACKGROUND_COLOR  = '#808080';
-// $CHAT_PRIMARY_COLOR         = '#003366';
-// $CHAT_PRIMARY_TEXT_COLOR    = '#ffffff';
-// $CHAT_USER_BUBBLE_COLOR     = '#0078d7';
-// $CHAT_USER_TEXT_COLOR       = '#ffffff';
-// $CHAT_BOT_BUBBLE_COLOR      = '#f0f0f0';
-// $CHAT_BOT_TEXT_COLOR        = '#000000';
-// $CHAT_LINK_COLOR            = '#003366';
-
 // Pfad zur FAQ‑Markdown‑Datei, die die Wissensbasis für das Hotel enthält.
 $FAQ_FILE = __DIR__ . '/data/faq.md';
 

--- a/core/init.php
+++ b/core/init.php
@@ -70,21 +70,8 @@ $chatbotThemeDefaults = [
     'THEME_COLOR_TEXT'              => '#0F172A',
 ];
 
-$chatbotThemeLegacyMap = [
-    'THEME_COLOR_BASE'             => isset($CHAT_BACKGROUND_COLOR) ? (string)$CHAT_BACKGROUND_COLOR : null,
-    'THEME_COLOR_SURFACE'          => isset($CHAT_BOX_BACKGROUND_COLOR) ? (string)$CHAT_BOX_BACKGROUND_COLOR : null,
-    'THEME_COLOR_PRIMARY'          => isset($CHAT_PRIMARY_COLOR) ? (string)$CHAT_PRIMARY_COLOR : null,
-    'THEME_COLOR_PRIMARY_CONTRAST' => isset($CHAT_PRIMARY_TEXT_COLOR) ? (string)$CHAT_PRIMARY_TEXT_COLOR : null,
-    'THEME_COLOR_TEXT'             => isset($CHAT_BOT_TEXT_COLOR) ? (string)$CHAT_BOT_TEXT_COLOR : null,
-];
-
 foreach ($chatbotThemeDefaults as $themeKey => $defaultHex) {
     $explicit = isset(${$themeKey}) ? chatbot_normalize_hex_color((string)${$themeKey}) : null;
-
-    if ($explicit === null) {
-        $legacy = $chatbotThemeLegacyMap[$themeKey] ?? null;
-        $explicit = chatbot_normalize_hex_color(is_string($legacy) ? $legacy : null);
-    }
 
     if ($explicit === null) {
         $explicit = $defaultHex;

--- a/core/partials/style_overrides.php
+++ b/core/partials/style_overrides.php
@@ -12,23 +12,8 @@ $themeDefaults = [
     'THEME_COLOR_TEXT'             => '#0F172A',
 ];
 
-$legacyTranslations = [
-    'THEME_COLOR_BASE'             => $CHAT_BACKGROUND_COLOR ?? null,
-    'THEME_COLOR_SURFACE'          => $CHAT_BOX_BACKGROUND_COLOR ?? null,
-    'THEME_COLOR_PRIMARY'          => $CHAT_PRIMARY_COLOR ?? null,
-    'THEME_COLOR_PRIMARY_CONTRAST' => $CHAT_PRIMARY_TEXT_COLOR ?? null,
-    'THEME_COLOR_TEXT'             => $CHAT_BOT_TEXT_COLOR ?? null,
-];
-
 foreach ($themeDefaults as $themeKey => $defaultHex) {
     $value = isset(${$themeKey}) ? chatbot_normalize_hex_color((string)${$themeKey}) : null;
-
-    if ($value === null) {
-        $legacy = $legacyTranslations[$themeKey] ?? null;
-        if (is_string($legacy)) {
-            $value = chatbot_normalize_hex_color($legacy);
-        }
-    }
 
     if ($value === null || $value === $defaultHex) {
         continue;


### PR DESCRIPTION
## Summary
- drop the CHAT_* → THEME_COLOR_* mapping so only current tokens are read
- clean the sample config and README to reference THEME_COLOR_* exclusively

## Testing
- php -l core/init.php
- php -l core/admin.php
- php -l core/partials/style_overrides.php
- php -r '$configPath="/tmp/test_config.php"; require "core/init.php"; echo json_encode(["base"=>$THEME_COLOR_BASE, "primary"=>$THEME_COLOR_PRIMARY], JSON_PRETTY_PRINT) . PHP_EOL;'
- php -r 'session_id("cli-test"); session_start(); $_SESSION["cli"] = true; session_write_close(); session_id("cli-test"); $ADMIN_SESSION_KEY = "cli"; $_SERVER["REQUEST_METHOD"] = "GET"; $_GET = []; $_POST = []; $_FILES = []; $configPath="/tmp/test_admin_config.php"; ob_start(); require "core/admin.php"; $html = ob_get_clean(); echo json_encode(["theme_base"=>$settingsValues["THEME_COLOR_BASE"] ?? null, "theme_primary"=>$settingsValues["THEME_COLOR_PRIMARY"] ?? null], JSON_PRETTY_PRINT), PHP_EOL;'


------
https://chatgpt.com/codex/tasks/task_e_68d542ececd48324957b08873809bdd0