### PR TITLE
Improve API resilience and add health check tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ external CDN.【F:core/init.php†L48-L118】
   logging routines in `core/init.php` automatically create the `logs` table and the
   analytics helpers aggregate question/answer statistics, hourly/daily usage, and top
   topics for operators.【F:core/init.php†L30-L71】【F:core/analytics_helpers.php†L1-L88】
+- **API health monitoring:** Optional errors can be persisted by defining
+  `$API_ERROR_LOG`. The CLI script `core/cli/health_check.php` pings the configured
+  API, measures latency, and stores the result in the shared SQLite database so that
+  the analytics dashboard can surface recent latencies and failure rates.【F:core/config.sample.php†L36-L38】【F:core/cli/health_check.php†L1-L123】【F:core/analytics_helpers.php†L1-L210】
 - **FAQ management:** The FAQ editor writes directly to the Markdown file defined by
   `$FAQ_FILE`, providing immediate context updates for the API’s retrieval step and the
   chat responses.【F:core/admin.php†L126-L170】【F:api/ask.php†L20-L43】

--- a/core/cli/health_check.php
+++ b/core/cli/health_check.php
@@ -1,0 +1,111 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+/**
+ * CLI-Skript zum Prüfen der Antwortlatenz der Chat-API.
+ */
+
+$options = getopt('', ['config::', 'question::']);
+$configPath = isset($options['config']) ? (string)$options['config'] : null;
+$question = isset($options['question']) ? trim((string)$options['question']) : 'PING';
+
+if ($configPath !== null && $configPath !== '') {
+    if (!file_exists($configPath)) {
+        fwrite(STDERR, "Konfigurationsdatei nicht gefunden: {$configPath}\n");
+        exit(1);
+    }
+    $configPath = realpath($configPath) ?: $configPath;
+    $GLOBALS['configPath'] = $configPath;
+}
+
+require_once __DIR__ . '/../init.php';
+require_once __DIR__ . '/../http_client.php';
+
+if (!isset($API_URL) || !$API_URL) {
+    fwrite(STDERR, "API_URL ist nicht konfiguriert.\n");
+    exit(1);
+}
+
+$payload = [
+    'messages' => [
+        ['role' => 'system', 'content' => 'Health check ping'],
+        ['role' => 'user', 'content' => $question !== '' ? $question : 'PING'],
+    ],
+    'conversation_id' => bin2hex(random_bytes(8)),
+];
+
+$payloadJson = json_encode($payload, JSON_UNESCAPED_UNICODE);
+if ($payloadJson === false) {
+    fwrite(STDERR, "Payload konnte nicht kodiert werden.\n");
+    exit(1);
+}
+
+$apiOptions = [
+    'max_attempts' => 3,
+    'connect_timeout' => 5,
+    'timeout' => 15,
+    'backoff_initial_ms' => 200,
+    'backoff_factor' => 2.0,
+];
+
+if (isset($API_ERROR_LOG) && is_string($API_ERROR_LOG) && $API_ERROR_LOG !== '') {
+    $apiOptions['error_log_path'] = $API_ERROR_LOG;
+}
+
+$start = microtime(true);
+$result = chatbot_post_json_with_retry($API_URL, $payloadJson, $apiOptions);
+$latencyMs = (microtime(true) - $start) * 1000;
+
+$statusCode = $result['status_code'] ?? null;
+$success = false;
+$errorCode = $result['error_code'] ?? null;
+$responseExcerpt = chatbot_truncate_for_log($result['body'] ?? null);
+
+if ($result['success']) {
+    $decoded = json_decode($result['body'] ?? '', true);
+    if (is_array($decoded) && isset($decoded['answer']) && !isset($decoded['error'])) {
+        $success = true;
+        if ($responseExcerpt === null && isset($decoded['answer'])) {
+            $responseExcerpt = chatbot_truncate_for_log((string)$decoded['answer']);
+        }
+    } else {
+        $success = false;
+        $errorCode = is_array($decoded) && isset($decoded['error_code'])
+            ? (string)$decoded['error_code']
+            : 'API_INVALID_RESPONSE';
+        if ($responseExcerpt === null) {
+            $responseExcerpt = chatbot_truncate_for_log($result['body'] ?? null);
+        }
+    }
+} else {
+    $success = false;
+}
+
+if ($db instanceof PDO) {
+    try {
+        $stmt = $db->prepare('INSERT INTO health_checks (status_code, latency_ms, success, error_code, response_excerpt) VALUES (:status_code, :latency_ms, :success, :error_code, :response_excerpt)');
+        $stmt->execute([
+            ':status_code' => $statusCode,
+            ':latency_ms' => $latencyMs,
+            ':success' => $success ? 1 : 0,
+            ':error_code' => $errorCode,
+            ':response_excerpt' => $responseExcerpt,
+        ]);
+    } catch (Throwable $e) {
+        fwrite(STDERR, "Health-Check konnte nicht protokolliert werden: " . $e->getMessage() . "\n");
+    }
+} else {
+    fwrite(STDERR, "Warnung: Keine Datenbankverbindung – Health-Check wird nicht gespeichert.\n");
+}
+
+if ($success) {
+    $latencyFormatted = number_format($latencyMs, 1, ',', '.');
+    echo "Health-Check erfolgreich: {$latencyFormatted} ms (HTTP " . ($statusCode ?? 0) . ")\n";
+    exit(0);
+}
+
+$latencyFormatted = number_format($latencyMs, 1, ',', '.');
+$codeText = $errorCode ?? 'API_REQUEST_FAILED';
+fwrite(STDERR, "Health-Check fehlgeschlagen ({$codeText}) nach {$latencyFormatted} ms" . ($statusCode ? " – HTTP {$statusCode}" : '') . "\n");
+exit(1);

--- a/core/config.sample.php
+++ b/core/config.sample.php
@@ -33,6 +33,9 @@ $FAQ_FILE = __DIR__ . '/data/faq.md';
 // Pfad zur SQLite‑Datenbank, in der Benutzerfragen und Antworten protokolliert werden.
 $LOG_DB = __DIR__ . '/data/logs.sqlite';
 
+// Optional: Datei für detaillierte API-Fehlerlogs (muss beschreibbar sein).
+// $API_ERROR_LOG = __DIR__ . '/data/api_errors.log';
+
 // URL der Haupt‑Hotel‑Website. Diese wird für den "Zurück zur Website"‑Link verwendet.
 $HOTEL_URL = 'https://www.example-hotel.de';
 

--- a/core/http_client.php
+++ b/core/http_client.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * HTTP-Hilfsfunktionen für den Aufruf der externen Chat-API.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Führt einen POST-Request mit JSON-Payload durch und liefert erweiterte Fehlerinformationen zurück.
+ *
+ * @param string $url
+ * @param string $payload
+ * @param array<string,mixed> $options
+ * @return array{
+ *   success:bool,
+ *   body:?string,
+ *   status_code:?int,
+ *   attempts:int,
+ *   error_code:?string,
+ *   error_message:?string,
+ *   curl_error:?string
+ * }
+ */
+function chatbot_post_json_with_retry(string $url, string $payload, array $options = []): array
+{
+    $maxAttempts = isset($options['max_attempts']) ? max(1, (int)$options['max_attempts']) : 3;
+    $connectTimeout = isset($options['connect_timeout']) ? max(1, (int)$options['connect_timeout']) : 10;
+    $timeout = isset($options['timeout']) ? max(1, (int)$options['timeout']) : 30;
+    $backoffInitialMs = isset($options['backoff_initial_ms']) ? max(50, (int)$options['backoff_initial_ms']) : 200;
+    $backoffFactor = isset($options['backoff_factor']) ? max(1.0, (float)$options['backoff_factor']) : 2.0;
+    $retryStatusCodes = isset($options['retry_status_codes']) && is_array($options['retry_status_codes'])
+        ? array_map('intval', $options['retry_status_codes'])
+        : [408, 425, 429, 500, 502, 503, 504];
+    $errorLogPath = isset($options['error_log_path']) && is_string($options['error_log_path']) && $options['error_log_path'] !== ''
+        ? $options['error_log_path']
+        : null;
+
+    $attempt = 0;
+    $lastStatusCode = null;
+    $lastBody = null;
+    $lastErrorCode = null;
+    $lastErrorMessage = null;
+    $lastCurlError = null;
+
+    while ($attempt < $maxAttempts) {
+        $attempt++;
+
+        $ch = curl_init($url);
+        if ($ch === false) {
+            $lastErrorCode = 'API_INIT_ERROR';
+            $lastErrorMessage = 'cURL konnte nicht initialisiert werden.';
+            break;
+        }
+
+        $headers = [
+            'Content-Type: application/json',
+            'Content-Length: ' . strlen($payload),
+        ];
+
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $payload,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_CONNECTTIMEOUT => $connectTimeout,
+            CURLOPT_TIMEOUT => $timeout,
+        ]);
+
+        $response = curl_exec($ch);
+        $curlErrNo = curl_errno($ch);
+        $curlError = $curlErrNo !== 0 ? curl_error($ch) : null;
+        $statusCode = (int)curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+        curl_close($ch);
+
+        $lastStatusCode = $statusCode > 0 ? $statusCode : null;
+        $lastBody = $response !== false ? (string)$response : null;
+        $lastCurlError = $curlError;
+
+        if ($response !== false && $statusCode >= 200 && $statusCode < 300) {
+            return [
+                'success' => true,
+                'body' => (string)$response,
+                'status_code' => $statusCode,
+                'attempts' => $attempt,
+                'error_code' => null,
+                'error_message' => null,
+                'curl_error' => null,
+            ];
+        }
+
+        $shouldRetry = false;
+        if ($response === false) {
+            if (in_array($curlErrNo, [CURLE_OPERATION_TIMEDOUT, CURLE_COULDNT_CONNECT, CURLE_COULDNT_RESOLVE_HOST, CURLE_COULDNT_RESOLVE_PROXY], true)) {
+                $shouldRetry = true;
+                $lastErrorCode = $curlErrNo === CURLE_OPERATION_TIMEDOUT ? 'API_TIMEOUT' : 'API_CONNECTION_ERROR';
+            } else {
+                $lastErrorCode = 'API_TRANSPORT_ERROR';
+            }
+            $lastErrorMessage = $curlError ?: 'Unbekannter Transportfehler';
+        } else {
+            $lastBody = (string)$response;
+            if ($statusCode === 0) {
+                $shouldRetry = true;
+                $lastErrorCode = 'API_NO_STATUS';
+                $lastErrorMessage = 'Kein HTTP-Statuscode erhalten.';
+            } elseif (in_array($statusCode, $retryStatusCodes, true)) {
+                $shouldRetry = true;
+                $lastErrorCode = $statusCode >= 500 ? 'API_HTTP_5XX' : 'API_HTTP_' . $statusCode;
+                $lastErrorMessage = 'HTTP-Status ' . $statusCode;
+            } elseif ($statusCode >= 400) {
+                $lastErrorCode = $statusCode >= 500 ? 'API_HTTP_5XX' : 'API_HTTP_' . $statusCode;
+                $lastErrorMessage = 'HTTP-Status ' . $statusCode;
+            } else {
+                $lastErrorCode = 'API_UNEXPECTED_STATUS';
+                $lastErrorMessage = 'Unerwarteter HTTP-Status ' . $statusCode;
+            }
+        }
+
+        if (!$shouldRetry) {
+            break;
+        }
+
+        if ($attempt < $maxAttempts) {
+            $sleepMs = (int)round($backoffInitialMs * pow($backoffFactor, $attempt - 1));
+            usleep($sleepMs * 1000);
+        }
+    }
+
+    if ($errorLogPath !== null) {
+        chatbot_append_api_error_log($errorLogPath, [
+            'url' => $url,
+            'status_code' => $lastStatusCode,
+            'error_code' => $lastErrorCode,
+            'error_message' => $lastErrorMessage,
+            'body_excerpt' => chatbot_truncate_for_log($lastBody),
+            'curl_error' => $lastCurlError,
+            'attempts' => $attempt,
+        ]);
+    }
+
+    return [
+        'success' => false,
+        'body' => $lastBody,
+        'status_code' => $lastStatusCode,
+        'attempts' => $attempt,
+        'error_code' => $lastErrorCode,
+        'error_message' => $lastErrorMessage,
+        'curl_error' => $lastCurlError,
+    ];
+}
+
+/**
+ * Schreibt einen Logeintrag in das optionale Fehlerlog.
+ *
+ * @param string $path
+ * @param array<string,mixed> $context
+ * @return void
+ */
+function chatbot_append_api_error_log(string $path, array $context): void
+{
+    $dir = dirname($path);
+    if (!is_dir($dir)) {
+        @mkdir($dir, 0775, true);
+    }
+
+    $entry = [
+        'timestamp' => date('c'),
+    ];
+
+    foreach ($context as $key => $value) {
+        if ($value === null || $value === '') {
+            continue;
+        }
+        $entry[$key] = $value;
+    }
+
+    $line = json_encode($entry, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    if ($line === false) {
+        $line = '[' . date('c') . '] ' . 'API error (json encoding failed)';
+    }
+
+    @file_put_contents($path, $line . PHP_EOL, FILE_APPEND | LOCK_EX);
+}
+
+/**
+ * Erstellt einen kompakten Ausschnitt für Logausgaben.
+ *
+ * @param string|null $body
+ * @return string|null
+ */
+function chatbot_truncate_for_log(?string $body): ?string
+{
+    if ($body === null || $body === '') {
+        return null;
+    }
+
+    if (function_exists('mb_substr')) {
+        $excerpt = mb_substr($body, 0, 500);
+    } else {
+        $excerpt = substr($body, 0, 500);
+    }
+
+    $excerpt = preg_replace('/\s+/u', ' ', $excerpt ?? '');
+    if ($excerpt === null) {
+        return null;
+    }
+
+    return trim($excerpt);
+}

--- a/core/init.php
+++ b/core/init.php
@@ -132,6 +132,15 @@ if (isset($LOG_DB) && is_string($LOG_DB)) {
         } catch (Exception $e) {
             // Spalte existiert bereits
         }
+        $db->exec('CREATE TABLE IF NOT EXISTS health_checks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            status_code INTEGER,
+            latency_ms REAL,
+            success INTEGER NOT NULL,
+            error_code TEXT,
+            response_excerpt TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )');
     } catch (Exception $e) {
         // Bei Fehlern die Verbindung null setzen
         $db = null;

--- a/core/partials/analysis_content.php
+++ b/core/partials/analysis_content.php
@@ -78,6 +78,60 @@
     </div>
 
     <div class="card span-12">
+      <h2>API‑Gesundheit</h2>
+      <?php $healthData = $analysisData['health'] ?? []; ?>
+      <?php if (!empty($healthData['error'])): ?>
+        <div class="muted">Health-Check-Daten konnten nicht gelesen werden: <?php echo htmlspecialchars((string)$healthData['error']); ?></div>
+      <?php elseif (empty($healthData['latest'])): ?>
+        <div class="muted">Noch keine Health-Checks aufgezeichnet.</div>
+      <?php else: ?>
+        <?php $latestHealth = $healthData['latest']; ?>
+        <p>
+          <strong>Letzte Messung:</strong>
+          <?php echo htmlspecialchars($latestHealth['created_at'] ?? ''); ?> ·
+          <?php echo ((int)($latestHealth['success'] ?? 0) === 1) ? 'OK' : 'Fehler'; ?>
+          <?php if (!empty($latestHealth['status_code'])): ?>
+            (HTTP <?php echo (int)$latestHealth['status_code']; ?>)
+          <?php endif; ?>
+          <?php if (isset($latestHealth['latency_ms'])): ?>
+            · <?php echo number_format((float)$latestHealth['latency_ms'], 1, ',', '.'); ?> ms
+          <?php endif; ?>
+        </p>
+        <p>
+          <strong>Ø Latenz (24h):</strong>
+          <?php echo isset($healthData['avg_latency_24h']) && $healthData['avg_latency_24h'] !== null
+              ? number_format((float)$healthData['avg_latency_24h'], 1, ',', '.') . ' ms'
+              : '–'; ?>
+        </p>
+        <p>
+          <strong>Checks (24h):</strong> <?php echo number_format((int)($healthData['checks_24h'] ?? 0), 0, ',', '.'); ?>
+          <?php if (isset($healthData['error_rate_24h']) && $healthData['error_rate_24h'] !== null): ?>
+            · <strong>Fehlerquote:</strong> <?php echo number_format($healthData['error_rate_24h'] * 100, 1, ',', '.'); ?>%
+          <?php endif; ?>
+        </p>
+        <?php if (!empty($healthData['last_error'])): ?>
+          <?php $lastHealthError = $healthData['last_error']; ?>
+          <p>
+            <strong>Letzter Fehler:</strong>
+            <?php echo htmlspecialchars($lastHealthError['created_at'] ?? ''); ?>
+            <?php if (!empty($lastHealthError['status_code'])): ?>
+              · HTTP <?php echo (int)$lastHealthError['status_code']; ?>
+            <?php endif; ?>
+            <?php if (!empty($lastHealthError['error_code'])): ?>
+              · <?php echo htmlspecialchars((string)$lastHealthError['error_code']); ?>
+            <?php endif; ?>
+          </p>
+          <?php if (!empty($lastHealthError['response_excerpt'])): ?>
+            <details>
+              <summary>Antwortauszug anzeigen</summary>
+              <pre><?php echo htmlspecialchars((string)$lastHealthError['response_excerpt']); ?></pre>
+            </details>
+          <?php endif; ?>
+        <?php endif; ?>
+      <?php endif; ?>
+    </div>
+
+    <div class="card span-12">
       <h2>Aktivitätsverlauf (letzte 30 Tage)</h2>
       <div class="table-scroll">
         <table>


### PR DESCRIPTION
## Summary
- replace the chat endpoint stream wrapper with a cURL-based client that adds timeouts, retries, logging and user-facing error codes
- introduce shared HTTP utilities plus a CLI health check that records latency samples and writes failures to the optional API error log
- extend the analytics backend/UI to surface health check metrics and document the new configuration in the README

## Testing
- php -l core/http_client.php
- php -l core/chat.php
- php -l core/init.php
- php -l core/analytics_helpers.php
- php -l core/partials/analysis_content.php
- php -l core/cli/health_check.php

------
https://chatgpt.com/codex/tasks/task_e_68d54715b138832485dcc7990629f5ae